### PR TITLE
[Refactor] 약속 후보 시간 테이블 생성에 따른 설계 변경

### DIFF
--- a/src/main/java/konkuk/kuit/baro/domain/promise/model/PromiseAvailableTime.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/model/PromiseAvailableTime.java
@@ -39,10 +39,6 @@ public class PromiseAvailableTime extends BaseEntity {
     @JoinColumn(name = "promise_member_id", nullable = false)
     private PromiseMember promiseMember;
 
-    // 제안된 약속 시간 삭제시, 약속 시간 투표 내역도 사라지도록 하기 위한 양방향 연관 관계
-    @OneToMany(mappedBy = "promiseAvailableTime", orphanRemoval = true)
-    private List<PromiseTimeVoteHistory> promiseTimeVoteHistories= new ArrayList<>();
-
 
     // 생성 메서드
     public static PromiseAvailableTime createPromiseAvailableTime(LocalDate availableDate, LocalTime availableStartTime, LocalTime availableEndTime, PromiseMember promiseMember) {
@@ -59,10 +55,6 @@ public class PromiseAvailableTime extends BaseEntity {
     private void setPromiseMember(PromiseMember promiseMember) {
         this.promiseMember = promiseMember;
         promiseMember.addPromiseAvailableTime(this);
-    }
-
-    public void addPromiseTimeVoteHistory(PromiseTimeVoteHistory promiseTimeVoteHistory) {
-        this.promiseTimeVoteHistories.add(promiseTimeVoteHistory);
     }
 
 }

--- a/src/main/java/konkuk/kuit/baro/domain/promise/model/PromiseCandidateTime.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/model/PromiseCandidateTime.java
@@ -1,6 +1,8 @@
 package konkuk.kuit.baro.domain.promise.model;
 
 import jakarta.persistence.*;
+import konkuk.kuit.baro.domain.vote.model.PromiseTimeVoteHistory;
+import konkuk.kuit.baro.domain.vote.model.PromiseVote;
 import konkuk.kuit.baro.global.common.model.BaseEntity;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -9,6 +11,8 @@ import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "promise_candidate_time")
@@ -29,6 +33,35 @@ public class PromiseCandidateTime extends BaseEntity {
 
     @Column(name = "promise_candidate_time_end_time", nullable = false)
     private LocalTime promiseCandidateTimeEndTime;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "promis_vote_id", nullable = false)
+    private PromiseVote promiseVote;
+
+    @OneToMany(mappedBy = "promiseCandidateTime", orphanRemoval = true)
+    private List<PromiseTimeVoteHistory> promiseTimeVoteHistories = new ArrayList<>();
+
+
+    // 생성 메서드
+    public static PromiseCandidateTime createPromiseCandidateTime(LocalDate promiseCandidateTimeDate, LocalTime promiseCandidateTimeStartTime, LocalTime promiseCandidateTimeEndTime, PromiseVote promiseVote) {
+        PromiseCandidateTime promiseCandidateTime = new PromiseCandidateTime();
+        promiseCandidateTime.promiseCandidateTimeDate = promiseCandidateTimeDate;
+        promiseCandidateTime.promiseCandidateTimeStartTime = promiseCandidateTimeStartTime;
+        promiseCandidateTime.promiseCandidateTimeEndTime = promiseCandidateTimeEndTime;
+        promiseCandidateTime.setPromiseVote(promiseVote);
+        return promiseCandidateTime;
+    }
+
+    // 연관 관계 편의 메서드
+    private void setPromiseVote(PromiseVote promiseVote) {
+        this.promiseVote = promiseVote;
+        promiseVote.addPromiseCandidateTime(this);
+    }
+
+    public void addPromiseTimeVoteHistory(PromiseTimeVoteHistory promiseTimeVoteHistory) {
+        this.promiseTimeVoteHistories.add(promiseTimeVoteHistory);
+    }
+
 
 
 

--- a/src/main/java/konkuk/kuit/baro/domain/promise/model/PromiseCandidateTime.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/model/PromiseCandidateTime.java
@@ -1,0 +1,35 @@
+package konkuk.kuit.baro.domain.promise.model;
+
+import jakarta.persistence.*;
+import konkuk.kuit.baro.global.common.model.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Entity
+@Table(name = "promise_candidate_time")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("status IN ('ACTIVE', 'PENDING', 'VOTING', 'CONFIRMED')")
+public class PromiseCandidateTime extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "promise_candidate_time_id", nullable = false)
+    private Long id;
+
+    @Column(name = "promise_candidate_time_date", nullable = false, columnDefinition = "DATE")
+    private LocalDate promiseCandidateTimeDate;
+
+    @Column(name = "promise_candidate_time_start_time", nullable = false)
+    private LocalTime promiseCandidateTimeStartTime;
+
+    @Column(name = "promise_candidate_time_end_time", nullable = false)
+    private LocalTime promiseCandidateTimeEndTime;
+
+
+
+}

--- a/src/main/java/konkuk/kuit/baro/domain/promise/repository/PromiseCandidateTimeRepository.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/repository/PromiseCandidateTimeRepository.java
@@ -1,0 +1,9 @@
+package konkuk.kuit.baro.domain.promise.repository;
+
+import konkuk.kuit.baro.domain.promise.model.PromiseCandidateTime;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PromiseCandidateTimeRepository extends JpaRepository<PromiseCandidateTime, Long> {
+}

--- a/src/main/java/konkuk/kuit/baro/domain/vote/model/PromisePlaceVoteHistory.java
+++ b/src/main/java/konkuk/kuit/baro/domain/vote/model/PromisePlaceVoteHistory.java
@@ -19,7 +19,7 @@ public class PromisePlaceVoteHistory extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "promise_place_vote_history", nullable = false)
+    @Column(name = "promise_place_vote_history_id", nullable = false)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/konkuk/kuit/baro/domain/vote/model/PromiseTimeVoteHistory.java
+++ b/src/main/java/konkuk/kuit/baro/domain/vote/model/PromiseTimeVoteHistory.java
@@ -27,20 +27,14 @@ public class PromiseTimeVoteHistory extends BaseEntity {
     private PromiseVote promiseVote;
 
     // 생성 메서드
-    public static PromiseTimeVoteHistory createPromiseTimeVoteHistory(PromiseAvailableTime promiseAvailableTime, PromiseVote promiseVote) {
+    public static PromiseTimeVoteHistory createPromiseTimeVoteHistory(PromiseVote promiseVote) {
         PromiseTimeVoteHistory promiseTimeVoteHistory = new PromiseTimeVoteHistory();
-        promiseTimeVoteHistory.setPromiseAvailableTime(promiseAvailableTime);
         promiseTimeVoteHistory.setPromiseVote(promiseVote);
 
         return promiseTimeVoteHistory;
     }
 
     // 연관 관계 편의 메서드
-    private void setPromiseAvailableTime(PromiseAvailableTime promiseAvailableTime) {
-        this.promiseAvailableTime = promiseAvailableTime;
-        promiseAvailableTime.addPromiseTimeVoteHistory(this);
-    }
-
     private void setPromiseVote(PromiseVote promiseVote) {
         this.promiseVote = promiseVote;
         promiseVote.addPromiseTimeVoteHistory(this);

--- a/src/main/java/konkuk/kuit/baro/domain/vote/model/PromiseTimeVoteHistory.java
+++ b/src/main/java/konkuk/kuit/baro/domain/vote/model/PromiseTimeVoteHistory.java
@@ -20,10 +20,6 @@ public class PromiseTimeVoteHistory extends BaseEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "promise_available_time_id", nullable = false)
-    private PromiseAvailableTime promiseAvailableTime;
-
-    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "promise_vote_id", nullable = false)
     private PromiseVote promiseVote;
 

--- a/src/main/java/konkuk/kuit/baro/domain/vote/model/PromiseTimeVoteHistory.java
+++ b/src/main/java/konkuk/kuit/baro/domain/vote/model/PromiseTimeVoteHistory.java
@@ -2,6 +2,7 @@ package konkuk.kuit.baro.domain.vote.model;
 
 import jakarta.persistence.*;
 import konkuk.kuit.baro.domain.promise.model.PromiseAvailableTime;
+import konkuk.kuit.baro.domain.promise.model.PromiseCandidateTime;
 import konkuk.kuit.baro.global.common.model.BaseEntity;
 import lombok.*;
 import org.hibernate.annotations.SQLRestriction;
@@ -15,7 +16,7 @@ import org.hibernate.annotations.SQLRestriction;
 public class PromiseTimeVoteHistory extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "promise_time_vote_history", nullable = false)
+    @Column(name = "promise_time_vote_history_id", nullable = false)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -26,11 +27,15 @@ public class PromiseTimeVoteHistory extends BaseEntity {
     @JoinColumn(name = "promise_vote_id", nullable = false)
     private PromiseVote promiseVote;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "promise_candidate_time_id", nullable = false)
+    private PromiseCandidateTime promiseCandidateTime;
+
     // 생성 메서드
-    public static PromiseTimeVoteHistory createPromiseTimeVoteHistory(PromiseVote promiseVote) {
+    public static PromiseTimeVoteHistory createPromiseTimeVoteHistory(PromiseVote promiseVote, PromiseCandidateTime promiseCandidateTime) {
         PromiseTimeVoteHistory promiseTimeVoteHistory = new PromiseTimeVoteHistory();
         promiseTimeVoteHistory.setPromiseVote(promiseVote);
-
+        promiseTimeVoteHistory.setPromiseCandidateTime(promiseCandidateTime);
         return promiseTimeVoteHistory;
     }
 
@@ -38,6 +43,11 @@ public class PromiseTimeVoteHistory extends BaseEntity {
     private void setPromiseVote(PromiseVote promiseVote) {
         this.promiseVote = promiseVote;
         promiseVote.addPromiseTimeVoteHistory(this);
+    }
+
+    private void setPromiseCandidateTime(PromiseCandidateTime promiseCandidateTime) {
+        this.promiseCandidateTime = promiseCandidateTime;
+        promiseCandidateTime.addPromiseTimeVoteHistory(this);
     }
 
 }

--- a/src/main/java/konkuk/kuit/baro/domain/vote/model/PromiseVote.java
+++ b/src/main/java/konkuk/kuit/baro/domain/vote/model/PromiseVote.java
@@ -1,6 +1,7 @@
 package konkuk.kuit.baro.domain.vote.model;
 
 import jakarta.persistence.*;
+import konkuk.kuit.baro.domain.promise.model.PromiseCandidateTime;
 import konkuk.kuit.baro.global.common.model.BaseEntity;
 import lombok.*;
 import org.hibernate.annotations.SQLRestriction;
@@ -24,12 +25,16 @@ public class PromiseVote extends BaseEntity {
     private LocalDateTime voteEndTime;
 
     // 투표된 시간들을 확인하기 위한 양방향 연관 관계
-    @OneToMany(mappedBy = "promiseVote", orphanRemoval = true)
+    @OneToMany(mappedBy = "promiseVote")
     private List<PromiseTimeVoteHistory> promiseTimeVoteHistories = new ArrayList<>();
 
     // 투표된 장소들을 확인하기 위한 양방향 연관 관계
     @OneToMany(mappedBy = "promiseVote", orphanRemoval = true)
     private List<PromisePlaceVoteHistory> promisePlaceVoteHistories = new ArrayList<>();
+
+    // 약속 후보 시간들을 확인하기 위한 양방향 연관 관계
+    @OneToMany(mappedBy = "promiseVote", orphanRemoval = true)
+    private List<PromiseCandidateTime> promiseCandidateTimes = new ArrayList<>();
 
     @Builder
     public PromiseVote(LocalDateTime voteEndTime) {
@@ -43,5 +48,9 @@ public class PromiseVote extends BaseEntity {
 
     public void addPromisePlaceVoteHistory(PromisePlaceVoteHistory promisePlaceVoteHistory) {
         this.promisePlaceVoteHistories.add(promisePlaceVoteHistory);
+    }
+
+    public void addPromiseCandidateTime(PromiseCandidateTime promiseCandidateTime) {
+        this.promiseCandidateTimes.add(promiseCandidateTime);
     }
 }

--- a/src/test/java/konkuk/kuit/baro/domain/promise/repository/PromiseCandidateTimeRepositoryTest.java
+++ b/src/test/java/konkuk/kuit/baro/domain/promise/repository/PromiseCandidateTimeRepositoryTest.java
@@ -1,0 +1,141 @@
+package konkuk.kuit.baro.domain.promise.repository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import konkuk.kuit.baro.domain.promise.model.Promise;
+import konkuk.kuit.baro.domain.promise.model.PromiseCandidateTime;
+import konkuk.kuit.baro.domain.promise.model.PromiseMember;
+import konkuk.kuit.baro.domain.user.model.User;
+import konkuk.kuit.baro.domain.user.repository.UserRepository;
+import konkuk.kuit.baro.domain.vote.model.PromiseVote;
+import konkuk.kuit.baro.domain.vote.repository.PromiseVoteRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class PromiseCandidateTimeRepositoryTest {
+
+    @Autowired
+    private PromiseRepository promiseRepository;
+    @Autowired
+    private PromiseMemberRepository promiseMemberRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private PromiseCandidateTimeRepository promiseCandidateTimeRepository;
+    @Autowired
+    private PromiseVoteRepository promiseVoteRepository;
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @BeforeEach
+    void init() {
+        User user = User.builder()
+                .email("hong@konkuk.ac.kr")
+                .name("홍길동")
+                .password("qwer1234!")
+                .profileImage("image.png")
+                .color("0XFFFF")
+                .build();
+
+        userRepository.save(user);
+
+        Promise promise = Promise.builder()
+                .promiseName("컴퓨터 공학부 개강파티")
+                .suggestedRegion("지그재그")
+                .suggestedStartDate(LocalDate.now().minusDays(1))
+                .suggestedEndDate(LocalDate.now().plusDays(1))
+                .build();
+
+        Promise savedPromise = promiseRepository.save(promise);
+
+        PromiseMember promiseMember = PromiseMember.createPromiseMember(true, user, promise);
+
+        promiseMemberRepository.save(promiseMember);
+
+        PromiseVote promiseVote = PromiseVote.builder()
+                .voteEndTime(LocalDateTime.now())
+                .build();
+
+        PromiseVote savedPromiseVote = promiseVoteRepository.save(promiseVote);
+
+        savedPromise.setPromiseVote(savedPromiseVote);
+
+    }
+
+    @Test
+    @DisplayName("약속 후보 시간 저장 테스트")
+    void save() {
+        // given
+        PromiseVote promiseVote = promiseVoteRepository.findById(1L).get();
+        PromiseCandidateTime promiseCandidateTime = PromiseCandidateTime.createPromiseCandidateTime(LocalDate.now(), LocalTime.now(), LocalTime.now().plusHours(1), promiseVote);
+
+        // when
+        promiseCandidateTimeRepository.save(promiseCandidateTime);
+
+        // then
+        assertThat(promiseCandidateTimeRepository.findById(1L).isPresent()).isTrue();
+    }
+
+    @Test
+    @DisplayName("약속 후보 시간 삭제 테스트")
+    void delete() {
+        // given
+        PromiseVote promiseVote = promiseVoteRepository.findById(1L).get();
+        PromiseCandidateTime promiseCandidateTime = PromiseCandidateTime.createPromiseCandidateTime(LocalDate.now(), LocalTime.now(), LocalTime.now().plusHours(1), promiseVote);
+
+        promiseCandidateTimeRepository.save(promiseCandidateTime);
+
+        em.flush();
+        em.clear();
+
+        // when
+        PromiseCandidateTime findPromiseCandidateTime = promiseCandidateTimeRepository.findById(1L).get();
+        promiseCandidateTimeRepository.delete(findPromiseCandidateTime);
+
+        em.flush();
+        em.clear();
+
+        // then
+        assertThat(promiseCandidateTimeRepository.findById(1L).isEmpty()).isTrue();
+    }
+
+    @Test
+    @DisplayName("약속을 삭제했을 때, 약속 후보 시간도 삭제되는지 테스트. 약속 삭제 -> 약속 투표 삭제 -> 약속 후보 시간 삭제")
+    void delete_promise() {
+        // given
+        PromiseVote promiseVote = promiseVoteRepository.findById(1L).get();
+        PromiseCandidateTime promiseCandidateTime = PromiseCandidateTime.createPromiseCandidateTime(LocalDate.now(), LocalTime.now(), LocalTime.now().plusHours(1), promiseVote);
+
+        promiseCandidateTimeRepository.save(promiseCandidateTime);
+
+        em.flush();
+        em.clear();
+
+        // when
+        Promise findPromise = promiseRepository.findById(1L).get();
+        promiseRepository.delete(findPromise);
+
+        em.flush();
+        em.clear();
+
+        // then
+        assertThat(promiseCandidateTimeRepository.findById(1L).isEmpty()).isTrue();
+
+    }
+
+}

--- a/src/test/java/konkuk/kuit/baro/domain/promise/repository/PromiseCandidateTimeRepositoryTest.java
+++ b/src/test/java/konkuk/kuit/baro/domain/promise/repository/PromiseCandidateTimeRepositoryTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Description;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
@@ -115,7 +116,8 @@ class PromiseCandidateTimeRepositoryTest {
     }
 
     @Test
-    @DisplayName("약속을 삭제했을 때, 약속 후보 시간도 삭제되는지 테스트. 약속 삭제 -> 약속 투표 삭제 -> 약속 후보 시간 삭제")
+    @DisplayName("약속 후보 시간 삭제 테스트")
+    @Description("약속을 삭제했을 때, 약속 후보 시간도 삭제되는지 테스트. 약속 삭제 -> 약속 투표 삭제 -> 약속 후보 시간 삭제")
     void delete_promise() {
         // given
         PromiseVote promiseVote = promiseVoteRepository.findById(1L).get();


### PR DESCRIPTION
## Related issue 🛠
- closed #9 

## Work Description 📝
- 약속 후보 시간 (promiseCandidateTime) 엔티티를 생성하였습니다.

- 연관 관계를 일부 수정하였습니다.
1. 약속 후보 시간 : 약속 투표 -> N : 1 (다대일)  => 하나의 약속 투표에 대해 여러개의 약속 후보 시간 존재 가능
2. 약속 시간 투표 내역 : 약속 후보 시간 -> N : 1 (다대일) => 하나의 약속 후보 시간에 대해 여러 명이 투표 가능
3. 약속 시간 투표 내역 : 약속 투표 -> N : 1 (다대일) => 하나의 약속 투표에 대해 여러 투표 내역이 존재 가능

- cascade 를 적용하였습니다.
=> 약속 삭제 -> 약속 투표 삭제 -> 약속 후보 시간 삭제 -> 약속 시간 투표 내역 삭제

-> 처음에는 약속 투표가 삭제될 시 약속 후보 시간, 약속 시간 투표 내역이 동시에 삭제되도록 하려고 했습니다.
다만 현재 erd 를 확인해보면, 약속 시간 투표 내역에 약속 후보 시간 ID 를 외래키로 관리하고 있으며, 외래키 제약조건으로 null 을 허용하지 않는 상태였습니다.
그러다보니 CASCADE 를 통해 약속 투표가 삭제될 때 약속 후보 시간, 약속 시간 투표 내역이 순차적이 아니라 동시에 삭제되도록 하면, 
약속 시간 투표 내역 삭제 -> 약속 후보 시간 삭제 순서로 엔티티가 삭제될 때는 외래키 제약 조건에 의한 예외가 터지지 않고 정상적으로 데이터가 삭제되지만, 
약속 후보 시간 삭제 -> 약속 시간 투표 내역 삭제 순서로 엔티티가 삭제될 때는 약속 시간 투표 내역에 연결되어있던 ID를 갖는 엔티티가 사라짐에 따라서 예외가 터지게됩니다. 
따라서 약속 삭제 -> 약속 투표 삭제 -> 약속 후보 시간 삭제 -> 약속 시간 투표 내역 삭제 순으로 CASCADE DELETE가 적용되도록 구현하였습니다.

일종의 트러블 슈팅이긴 한데 공유하면 좋을 것 같아서 적어두겠습니다

## Screenshot 📸
<img width="1000" alt="스크린샷 2025-03-05 오후 5 29 14" src="https://github.com/user-attachments/assets/164c962b-bb98-4b44-b232-403d5fd5ef60" />

## Uncompleted Tasks 😅
- 없습니다.

## To Reviewers 📢
