### PR TITLE
[Feat] 마이페이지 - 프로필 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	// Swagger
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
 	// JWT -> 원하는 버전 사용
 	// implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/main/java/konkuk/kuit/baro/domain/promise/controller/PromiseController.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/controller/PromiseController.java
@@ -3,6 +3,8 @@ package konkuk.kuit.baro.domain.promise.controller;
 import jakarta.validation.Valid;
 import konkuk.kuit.baro.domain.promise.dto.request.PromiseSuggestRequestDTO;
 import konkuk.kuit.baro.domain.promise.service.PromiseService;
+import konkuk.kuit.baro.global.common.annotation.CustomExceptionDescription;
+import konkuk.kuit.baro.global.common.config.swagger.SwaggerResponseDescription;
 import konkuk.kuit.baro.global.common.response.BaseResponse;
 import konkuk.kuit.baro.global.common.response.status.SuccessCode;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/konkuk/kuit/baro/domain/user/controller/UserController.java
+++ b/src/main/java/konkuk/kuit/baro/domain/user/controller/UserController.java
@@ -1,0 +1,38 @@
+package konkuk.kuit.baro.domain.user.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import konkuk.kuit.baro.domain.user.dto.request.UserUpdateProfileRequestDTO;
+import konkuk.kuit.baro.domain.user.service.UserService;
+import konkuk.kuit.baro.global.common.annotation.CustomExceptionDescription;
+import konkuk.kuit.baro.global.common.config.swagger.SwaggerResponseDescription;
+import konkuk.kuit.baro.global.common.response.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static konkuk.kuit.baro.global.common.config.swagger.SwaggerResponseDescription.*;
+
+@Slf4j
+@RestController
+@RequestMapping("users")
+@RequiredArgsConstructor
+public class UserController {
+    private final UserService userService;
+
+    @Tag(name = "My Page", description = "유저 마이페이지 관련 API")
+    @Operation(summary = "유저 프로필 수정", description = "유저의 이름, 프로필 사진을 변경합니다.")
+    @PostMapping("profile")
+    @CustomExceptionDescription(USER_PROFILE_UPDATE)
+    public BaseResponse<Void> updateProfile(@RequestBody @Validated UserUpdateProfileRequestDTO req){
+        userService.updateProfile(req);
+        return BaseResponse.ok(null);
+
+    }
+
+}

--- a/src/main/java/konkuk/kuit/baro/domain/user/controller/UserController.java
+++ b/src/main/java/konkuk/kuit/baro/domain/user/controller/UserController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import konkuk.kuit.baro.domain.user.dto.request.UserUpdateProfileRequestDTO;
+import konkuk.kuit.baro.domain.user.dto.response.UserProfileResponseDTO;
 import konkuk.kuit.baro.domain.user.service.UserService;
 import konkuk.kuit.baro.global.common.annotation.CustomExceptionDescription;
 import konkuk.kuit.baro.global.common.config.swagger.SwaggerResponseDescription;
@@ -11,10 +12,7 @@ import konkuk.kuit.baro.global.common.response.BaseResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static konkuk.kuit.baro.global.common.config.swagger.SwaggerResponseDescription.*;
 
@@ -33,6 +31,14 @@ public class UserController {
         userService.updateProfile(req);
         return BaseResponse.ok(null);
 
+    }
+
+    @Tag(name = "My Page", description = "유저 마이페이지 관련 API")
+    @Operation(summary = "유저 프로필 수정 화면", description = "프로필 수정 기능 호출 시 프로필을 조회하는 기능입니다.")
+    @GetMapping("profile/")
+    @CustomExceptionDescription(USER_PROFILE)
+    public BaseResponse<UserProfileResponseDTO> getProfile(Long userId){
+        return BaseResponse.ok(userService.getProfile(userId));
     }
 
 }

--- a/src/main/java/konkuk/kuit/baro/domain/user/controller/UserController.java
+++ b/src/main/java/konkuk/kuit/baro/domain/user/controller/UserController.java
@@ -35,7 +35,7 @@ public class UserController {
 
     @Tag(name = "My Page", description = "유저 마이페이지 관련 API")
     @Operation(summary = "유저 프로필 수정 화면", description = "프로필 수정 기능 호출 시 프로필을 조회하는 기능입니다.")
-    @GetMapping("profile/")
+    @GetMapping("profile")
     @CustomExceptionDescription(USER_PROFILE)
     public BaseResponse<UserProfileResponseDTO> getProfile(Long userId){
         return BaseResponse.ok(userService.getProfile(userId));

--- a/src/main/java/konkuk/kuit/baro/domain/user/dto/request/UserUpdateProfileRequestDTO.java
+++ b/src/main/java/konkuk/kuit/baro/domain/user/dto/request/UserUpdateProfileRequestDTO.java
@@ -1,0 +1,20 @@
+package konkuk.kuit.baro.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserUpdateProfileRequestDTO {
+    @Schema(description = "이름", example = "이정연")
+    @NotNull
+    private String newName;
+
+    @Schema(description = "프로필 사진",example = "image1")
+    @NotNull
+    private String newProfileImage;
+
+}

--- a/src/main/java/konkuk/kuit/baro/domain/user/dto/response/UserProfileResponseDTO.java
+++ b/src/main/java/konkuk/kuit/baro/domain/user/dto/response/UserProfileResponseDTO.java
@@ -1,0 +1,18 @@
+package konkuk.kuit.baro.domain.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class UserProfileResponseDTO {
+    @Schema(description = "이름", example = "이정연")
+    private String name;
+
+    @Schema(description = "프로필 사진", example = "image")
+    private String profileImage;
+}

--- a/src/main/java/konkuk/kuit/baro/domain/user/model/User.java
+++ b/src/main/java/konkuk/kuit/baro/domain/user/model/User.java
@@ -18,6 +18,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE users SET status = 2 WHERE user_id = ?")
 @SQLRestriction("status IN ('ACTIVE', 'PENDING', 'VOTING', 'CONFIRMED')")
+@Setter
 public class User extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/konkuk/kuit/baro/domain/user/service/UserService.java
+++ b/src/main/java/konkuk/kuit/baro/domain/user/service/UserService.java
@@ -1,0 +1,33 @@
+package konkuk.kuit.baro.domain.user.service;
+
+import konkuk.kuit.baro.domain.user.dto.request.UserUpdateProfileRequestDTO;
+import konkuk.kuit.baro.domain.user.model.User;
+import konkuk.kuit.baro.domain.user.repository.UserRepository;
+import konkuk.kuit.baro.global.common.exception.CustomException;
+import konkuk.kuit.baro.global.common.response.status.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+
+    public void updateProfile(UserUpdateProfileRequestDTO req) {
+        User loginUser = userRepository.findById(1L).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        validateName(req.getNewName());
+
+        loginUser.setName(req.getNewName());
+        loginUser.setProfileImage(req.getNewProfileImage());
+        userRepository.save(loginUser);
+    }
+
+    private void validateName(String name){
+        if(name.length() > 12){
+            throw new CustomException(ErrorCode.USER_NAME_LENGTH);
+        }
+    }
+}

--- a/src/main/java/konkuk/kuit/baro/domain/user/service/UserService.java
+++ b/src/main/java/konkuk/kuit/baro/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package konkuk.kuit.baro.domain.user.service;
 
 import konkuk.kuit.baro.domain.user.dto.request.UserUpdateProfileRequestDTO;
+import konkuk.kuit.baro.domain.user.dto.response.UserProfileResponseDTO;
 import konkuk.kuit.baro.domain.user.model.User;
 import konkuk.kuit.baro.domain.user.repository.UserRepository;
 import konkuk.kuit.baro.global.common.exception.CustomException;
@@ -30,4 +31,11 @@ public class UserService {
             throw new CustomException(ErrorCode.USER_NAME_LENGTH);
         }
     }
+
+    public UserProfileResponseDTO getProfile(Long userId){
+        User loginUser = userRepository.findById(1L).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        return new UserProfileResponseDTO(loginUser.getName(), loginUser.getProfileImage());
+    }
+
+
 }

--- a/src/main/java/konkuk/kuit/baro/domain/user/service/UserService.java
+++ b/src/main/java/konkuk/kuit/baro/domain/user/service/UserService.java
@@ -9,6 +9,7 @@ import konkuk.kuit.baro.global.common.response.status.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Slf4j
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Service;
 public class UserService {
     private final UserRepository userRepository;
 
+    @Transactional
     public void updateProfile(UserUpdateProfileRequestDTO req) {
         User loginUser = userRepository.findById(1L).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 

--- a/src/main/java/konkuk/kuit/baro/global/common/annotation/CustomExceptionDescription.java
+++ b/src/main/java/konkuk/kuit/baro/global/common/annotation/CustomExceptionDescription.java
@@ -1,0 +1,15 @@
+package konkuk.kuit.baro.global.common.annotation;
+
+import konkuk.kuit.baro.global.common.config.swagger.SwaggerResponseDescription;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CustomExceptionDescription {
+
+    SwaggerResponseDescription value();
+}

--- a/src/main/java/konkuk/kuit/baro/global/common/config/swagger/ExampleHolder.java
+++ b/src/main/java/konkuk/kuit/baro/global/common/config/swagger/ExampleHolder.java
@@ -1,0 +1,14 @@
+package konkuk.kuit.baro.global.common.config.swagger;
+
+import io.swagger.v3.oas.models.examples.Example;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ExampleHolder {
+
+    private Example holder;
+    private String name;
+    private int code;
+}

--- a/src/main/java/konkuk/kuit/baro/global/common/config/swagger/SwaggerConfig.java
+++ b/src/main/java/konkuk/kuit/baro/global/common/config/swagger/SwaggerConfig.java
@@ -4,8 +4,27 @@ import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import konkuk.kuit.baro.global.common.annotation.CustomExceptionDescription;
+import konkuk.kuit.baro.global.common.response.BaseErrorResponse;
+import konkuk.kuit.baro.global.common.response.status.ErrorCode;
+import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.ErrorResponse;
+import org.springframework.web.method.HandlerMethod;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.stream.Collectors.groupingBy;
 
 @OpenAPIDefinition(
         info = @Info(
@@ -20,5 +39,69 @@ public class SwaggerConfig {
         public OpenAPI openAPI() {
                 return new OpenAPI()
                         .components(new Components());
+        }
+        @Bean
+        public OperationCustomizer customize() {
+                return (Operation operation, HandlerMethod handlerMethod) -> {
+
+                        CustomExceptionDescription customExceptionDescription = handlerMethod.getMethodAnnotation(
+                                CustomExceptionDescription.class);
+
+                        // CustomExceptionDescription 어노테이션 단 메소드 적용
+                        if (customExceptionDescription != null) {
+                                generateErrorCodeResponseExample(operation, customExceptionDescription.value());
+                        }
+
+                        return operation;
+                };
+        }
+        private void generateErrorCodeResponseExample(
+                Operation operation, SwaggerResponseDescription type) {
+
+                ApiResponses responses = operation.getResponses();
+
+                Set<ErrorCode> errorCodeList = type.getErrorCodeList();
+
+                Map<Integer, List<ExampleHolder>> statusWithExampleHolders =
+                        errorCodeList.stream()
+                                .map(
+                                        errorCode -> {
+                                                return ExampleHolder.builder()
+                                                        .holder(
+                                                                getSwaggerExample(errorCode))
+                                                        .code(errorCode.getCode())
+                                                        .name(errorCode.toString())
+                                                        .build();
+                                        }
+                                ).collect(groupingBy(ExampleHolder::getCode));
+                addExamplesToResponses(responses, statusWithExampleHolders);
+        }
+
+        private Example getSwaggerExample(ErrorCode errorCode) {
+                Map<String, String> result = new LinkedHashMap<>();
+                BaseErrorResponse errorResponse = new BaseErrorResponse(errorCode);
+                Example example = new Example();
+                example.description(errorCode.getMessage());
+                example.setValue(errorResponse);
+                return example;
+        }
+
+        private void addExamplesToResponses(
+                ApiResponses responses, Map<Integer, List<ExampleHolder>> statusWithExampleHolders) {
+                statusWithExampleHolders.forEach(
+                        (status, v) -> {
+                                Content content = new Content();
+                                MediaType mediaType = new MediaType();
+                                ApiResponse apiResponse = new ApiResponse();
+                                v.forEach(
+                                        exampleHolder -> {
+                                                mediaType.addExamples(
+                                                        exampleHolder.getName(), exampleHolder.getHolder());
+                                        });
+                                content.addMediaType("application/json", mediaType);
+                                apiResponse.setDescription("");
+                                apiResponse.setContent(content);
+                                responses.addApiResponse(status.toString(), apiResponse);
+                        });
         }
 }

--- a/src/main/java/konkuk/kuit/baro/global/common/config/swagger/SwaggerConfig.java
+++ b/src/main/java/konkuk/kuit/baro/global/common/config/swagger/SwaggerConfig.java
@@ -1,0 +1,24 @@
+package konkuk.kuit.baro.global.common.config.swagger;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@OpenAPIDefinition(
+        info = @Info(
+                title = "Baro 백엔드 API 명세서",
+                description = "Springdoc을 이용한 Swagger API 문서입니다.",
+                version = "1.0"
+        )
+)
+@Configuration
+public class SwaggerConfig {
+        @Bean
+        public OpenAPI openAPI() {
+                return new OpenAPI()
+                        .components(new Components());
+        }
+}

--- a/src/main/java/konkuk/kuit/baro/global/common/config/swagger/SwaggerConfig.java
+++ b/src/main/java/konkuk/kuit/baro/global/common/config/swagger/SwaggerConfig.java
@@ -69,7 +69,7 @@ public class SwaggerConfig {
                                                 return ExampleHolder.builder()
                                                         .holder(
                                                                 getSwaggerExample(errorCode))
-                                                        .code(errorCode.getCode())
+                                                        .code(errorCode.getHttpStatus())
                                                         .name(errorCode.toString())
                                                         .build();
                                         }

--- a/src/main/java/konkuk/kuit/baro/global/common/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/kuit/baro/global/common/config/swagger/SwaggerResponseDescription.java
@@ -10,7 +10,9 @@ import static konkuk.kuit.baro.global.common.response.status.ErrorCode.*;
 
 @Getter
 public enum SwaggerResponseDescription {
-    ;
+    USER_PROFILE_UPDATE(new LinkedHashSet<>(Set.of(
+            USER_NAME_LENGTH
+    )));
     private Set<ErrorCode> errorCodeList;
     SwaggerResponseDescription(Set<ErrorCode> errorCodeList) {
         // 공통 에러

--- a/src/main/java/konkuk/kuit/baro/global/common/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/kuit/baro/global/common/config/swagger/SwaggerResponseDescription.java
@@ -1,0 +1,32 @@
+package konkuk.kuit.baro.global.common.config.swagger;
+
+import konkuk.kuit.baro.global.common.response.status.ErrorCode;
+import lombok.Getter;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static konkuk.kuit.baro.global.common.response.status.ErrorCode.*;
+
+@Getter
+public enum SwaggerResponseDescription {
+    ;
+    private Set<ErrorCode> errorCodeList;
+    SwaggerResponseDescription(Set<ErrorCode> errorCodeList) {
+        // 공통 에러
+        errorCodeList.addAll(new LinkedHashSet<>(Set.of(
+                ILLEGAL_ARGUMENT,
+                NOT_FOUND,
+                METHOD_NOT_ALLOWED,
+                SERVER_ERROR,
+                UNAUTHORIZED,
+                FORBIDDEN
+        )));
+
+        if (this.name().contains("USER_")) {
+            errorCodeList.add(USER_NOT_FOUND);
+        }
+
+        this.errorCodeList = errorCodeList;
+    }
+}

--- a/src/main/java/konkuk/kuit/baro/global/common/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/kuit/baro/global/common/config/swagger/SwaggerResponseDescription.java
@@ -11,7 +11,11 @@ import static konkuk.kuit.baro.global.common.response.status.ErrorCode.*;
 @Getter
 public enum SwaggerResponseDescription {
     USER_PROFILE_UPDATE(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND,
             USER_NAME_LENGTH
+    ))),
+    USER_PROFILE(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND
     )));
     private Set<ErrorCode> errorCodeList;
     SwaggerResponseDescription(Set<ErrorCode> errorCodeList) {
@@ -25,9 +29,6 @@ public enum SwaggerResponseDescription {
                 FORBIDDEN
         )));
 
-        if (this.name().contains("USER_")) {
-            errorCodeList.add(USER_NOT_FOUND);
-        }
 
         this.errorCodeList = errorCodeList;
     }

--- a/src/main/java/konkuk/kuit/baro/global/common/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/kuit/baro/global/common/config/swagger/SwaggerResponseDescription.java
@@ -17,7 +17,7 @@ public enum SwaggerResponseDescription {
     USER_PROFILE(new LinkedHashSet<>(Set.of(
             USER_NOT_FOUND
     )));
-    private Set<ErrorCode> errorCodeList;
+    private final Set<ErrorCode> errorCodeList;
     SwaggerResponseDescription(Set<ErrorCode> errorCodeList) {
         // 공통 에러
         errorCodeList.addAll(new LinkedHashSet<>(Set.of(

--- a/src/main/java/konkuk/kuit/baro/global/common/response/BaseResponse.java
+++ b/src/main/java/konkuk/kuit/baro/global/common/response/BaseResponse.java
@@ -19,12 +19,6 @@ public class BaseResponse<T> {
     private final String message;
     private final T data;
 
-    public BaseResponse(T data) {
-        this.success = true;
-        this.code = SUCCESS.getHttpStatus();   // 의논 사항
-        this.message = SUCCESS.getMessage();   // 의논 사항
-        this.data = data;
-    }
 
     public BaseResponse(ResponseStatus status, T data) {
         this.success = true;
@@ -33,18 +27,14 @@ public class BaseResponse<T> {
         this.data = data;
     }
 
-    public BaseResponse(int code, String message, T data) {
+    private BaseResponse(T data) {
         this.success = true;
-        this.code = code;
-        this.message = message;
+        this.code = 200;
+        this.message = "요청에 성공하였습니다.";
         this.data = data;
     }
 
-    public static <T> BaseResponse<T> of(int code, String message, T data) {
-        return new BaseResponse<>(code, message, data);
-    }
-
     public static <T> BaseResponse<T> ok(T data) {
-        return of(200, "성공하였습니다.", data);
+        return new BaseResponse<>(data);
     }
 }

--- a/src/main/java/konkuk/kuit/baro/global/common/response/BaseResponse.java
+++ b/src/main/java/konkuk/kuit/baro/global/common/response/BaseResponse.java
@@ -32,4 +32,19 @@ public class BaseResponse<T> {
         this.message = status.getMessage();
         this.data = data;
     }
+
+    public BaseResponse(int code, String message, T data) {
+        this.success = true;
+        this.code = code;
+        this.message = message;
+        this.data = data;
+    }
+
+    public static <T> BaseResponse<T> of(int code, String message, T data) {
+        return new BaseResponse<>(code, message, data);
+    }
+
+    public static <T> BaseResponse<T> ok(T data) {
+        return of(1, "성공하였습니다.", data);
+    }
 }

--- a/src/main/java/konkuk/kuit/baro/global/common/response/BaseResponse.java
+++ b/src/main/java/konkuk/kuit/baro/global/common/response/BaseResponse.java
@@ -45,6 +45,6 @@ public class BaseResponse<T> {
     }
 
     public static <T> BaseResponse<T> ok(T data) {
-        return of(1, "성공하였습니다.", data);
+        return of(200, "성공하였습니다.", data);
     }
 }

--- a/src/main/java/konkuk/kuit/baro/global/common/response/status/ErrorCode.java
+++ b/src/main/java/konkuk/kuit/baro/global/common/response/status/ErrorCode.java
@@ -14,7 +14,8 @@ public enum ErrorCode implements ResponseStatus {
     NOT_FOUND(101, HttpStatus.NOT_FOUND.value(), "존재하지 않는 API 입니다."),
     METHOD_NOT_ALLOWED(102, HttpStatus.METHOD_NOT_ALLOWED.value(), "유효하지 않은 Http 메서드입니다."),
     SERVER_ERROR(103, INTERNAL_SERVER_ERROR.value(), "서버에 오류가 발생했습니다."),
-
+    UNAUTHORIZED(104,HttpStatus.UNAUTHORIZED.value(),"인증 자격이 없습니다."),
+    FORBIDDEN(105,HttpStatus.FORBIDDEN.value(), "권한이 없습니다."),
     // 유저
     USER_NOT_FOUND(201, HttpStatus.NOT_FOUND.value(), "존재하지 않는 유저입니다.");
 

--- a/src/main/java/konkuk/kuit/baro/global/common/response/status/ErrorCode.java
+++ b/src/main/java/konkuk/kuit/baro/global/common/response/status/ErrorCode.java
@@ -17,8 +17,8 @@ public enum ErrorCode implements ResponseStatus {
     UNAUTHORIZED(104,HttpStatus.UNAUTHORIZED.value(),"인증 자격이 없습니다."),
     FORBIDDEN(105,HttpStatus.FORBIDDEN.value(), "권한이 없습니다."),
     // 유저
-    USER_NOT_FOUND(201, HttpStatus.NOT_FOUND.value(), "존재하지 않는 유저입니다.");
-
+    USER_NOT_FOUND(201, HttpStatus.NOT_FOUND.value(), "존재하지 않는 유저입니다."),
+    USER_NAME_LENGTH(202, BAD_REQUEST.value(), "이름은 12자 이하입니다.");
     @Getter
     private final int code;
     private final int httpStatus;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,7 +20,7 @@ spring:
     driver-class-name: org.h2.Driver
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## Related issue 🛠
- closed #8 

## Work Description 📝
- Swagger 명세서 자동화
- 프로필 수정 기능
- 프로필 수정 호출 시 기존 프로필 정보 조회하는 기능

## Screenshot 📸
<img src="" width="360"/>

## Uncompleted Tasks 😅
- 아직 LoginArgumentResolver가 없어 userId를 일시적으로 파라미터로 받도록 했습니다.
## To Reviewers 📢
논의사항 1. 현재 Swagger 설정으로 다양한 에러 Response들을 Swagger에 문서화 시켜놨습니다. 노션에 일일히 적는게 불편하다고 생각해서 구현을 해놨습니다.
<img width="345" alt="스크린샷 2025-03-07 오후 11 18 35" src="https://github.com/user-attachments/assets/38c5ce2e-6c36-43ee-ba7f-73502769130b" />
<img width="330" alt="스크린샷 2025-03-07 오후 11 18 55" src="https://github.com/user-attachments/assets/f4e9eccf-5a07-4811-800a-067949132ab8" />
API마다 SwaggerResponseDescription에 발생할 수 있는 ErrorCode를 적어놓고, 커스텀 어노테이션을 Controller에 선언하여 자동화시키는 방식입니다. 공통적으로 발생할 수 있는 Error들은 자동으로 추가되도록 해놨습니다. 노션에다가 적는 방식 vs 코드로 자동화하는 방식 중 어떤 것이 더 좋은 방법이라고 생각하시는지 궁금합니다.

논의사항 2. 현재 SuccessCode를 보면 API마다 SuccessCode를 다르게 해서 반환하는 형태로 구현되어 있는데, 저는 Success의 경우에는 굳이 code를 다 다르게 할 이유가 없다고 생각합니다. 그래서 현재 BaseResponse에 메서드를 구현해놓았는데, API마다 SuccessCode를 선언하기 보단 구현한 메서드를 반환하여 편리성을 높이는 방향으로 가는 것은 어떤지 의견이 궁금합니다!