### PR TITLE
[Fix] 테두리 색상 정보를 약속 참여자 테이블로 이동

### DIFF
--- a/src/main/java/konkuk/kuit/baro/domain/promise/controller/PromiseController.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/controller/PromiseController.java
@@ -18,7 +18,7 @@ import static konkuk.kuit.baro.global.common.config.swagger.SwaggerResponseDescr
 
 @Slf4j
 @RestController
-@RequestMapping("/promise")
+@RequestMapping("/promises")
 @RequiredArgsConstructor
 public class PromiseController {
 

--- a/src/main/java/konkuk/kuit/baro/domain/promise/model/PromiseMember.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/model/PromiseMember.java
@@ -28,6 +28,9 @@ public class PromiseMember extends BaseEntity {
     @Column(name = "is_host", nullable = false, columnDefinition = "TINYINT")
     private Boolean isHost;
 
+    @Column(name = "color", length = 20, nullable = false)
+    private String color;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
@@ -45,9 +48,10 @@ public class PromiseMember extends BaseEntity {
     private List<PromiseAvailableTime> promiseAvailableTimes = new ArrayList<>();
 
     // 생성 메서드
-    public static PromiseMember createPromiseMember(Boolean isHost, User user, Promise promise) {
+    public static PromiseMember createPromiseMember(Boolean isHost, String color, User user, Promise promise) {
         PromiseMember promiseMember = new PromiseMember();
         promiseMember.isHost = isHost;
+        promiseMember.color = color;
         promiseMember.setUser(user);
         promiseMember.setPromise(promise);
 

--- a/src/main/java/konkuk/kuit/baro/domain/promise/repository/PromiseMemberRepository.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/repository/PromiseMemberRepository.java
@@ -2,8 +2,14 @@ package konkuk.kuit.baro.domain.promise.repository;
 
 import konkuk.kuit.baro.domain.promise.model.PromiseMember;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface PromiseMemberRepository extends JpaRepository<PromiseMember, Long> {
+
+    @Query("SELECT pm.color FROM PromiseMember pm WHERE pm.id = :promiseId")
+    List<String> findColorsByPromiseId(Long promiseId);
 }

--- a/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
@@ -9,6 +9,7 @@ import konkuk.kuit.baro.domain.user.model.User;
 import konkuk.kuit.baro.domain.user.repository.UserRepository;
 import konkuk.kuit.baro.global.common.exception.CustomException;
 import konkuk.kuit.baro.global.common.response.status.ErrorCode;
+import konkuk.kuit.baro.global.common.util.ColorUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -22,6 +23,8 @@ public class PromiseService {
     private final PromiseRepository promiseRepository;
     private final PromiseMemberRepository promiseMemberRepository;
     private final UserRepository userRepository;
+
+    private final ColorUtil colorUtil;
 
     @Transactional
     public void promiseSuggest(PromiseSuggestRequestDTO request, Long loginUserId) {
@@ -40,8 +43,11 @@ public class PromiseService {
         // 로그인한 유저 찾기
         User loginUser = findLoginUser(loginUserId);
 
+        // 테두리 색상 설정
+        String borderColor = colorUtil.generateRandomHexColor(savedPromise.getId());
+
         // 약속 참여자 엔티티 생성
-        PromiseMember promiseMember = PromiseMember.createPromiseMember(true, loginUser, savedPromise);
+        PromiseMember promiseMember = PromiseMember.createPromiseMember(true, borderColor, loginUser, savedPromise);
 
         // 약속 참여자 엔티티 저장
         promiseMemberRepository.save(promiseMember);

--- a/src/main/java/konkuk/kuit/baro/domain/user/model/User.java
+++ b/src/main/java/konkuk/kuit/baro/domain/user/model/User.java
@@ -38,9 +38,6 @@ public class User extends BaseEntity {
     @Column(name = "profile_image", nullable = false)
     private String profileImage;
 
-    @Column(name = "color", length = 20, nullable = false)
-    private String color;
-
     // 일정을 확인하기 위한 양방향 연관 관계
     @OneToMany(mappedBy = "user", orphanRemoval = true)
     private List<Schedule> schedules = new ArrayList<>();
@@ -54,12 +51,11 @@ public class User extends BaseEntity {
     private List<PromiseMember> promiseMembers = new ArrayList<>();
 
     @Builder
-    public User(String email, String password, String name, String profileImage, String color) {
+    public User(String email, String password, String name, String profileImage) {
         this.email = email;
         this.password = password;
         this.name = name;
         this.profileImage = profileImage;
-        this.color = color;
     }
 
     // 연관 관계 편의 메서드

--- a/src/main/java/konkuk/kuit/baro/global/common/util/ColorUtil.java
+++ b/src/main/java/konkuk/kuit/baro/global/common/util/ColorUtil.java
@@ -1,0 +1,40 @@
+package konkuk.kuit.baro.global.common.util;
+
+
+import konkuk.kuit.baro.domain.promise.repository.PromiseMemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class ColorUtil {
+
+    private static final Random RANDOM = new Random();
+    private final PromiseMemberRepository promiseMemberRepository;
+
+    public String generateRandomHexColor(Long promiseId) {
+        List<String> existingColors = promiseMemberRepository.findColorsByPromiseId(promiseId);
+        Set<String> existingColorSet = new HashSet<>(existingColors);
+
+        String randomColor;
+
+        do {
+            randomColor = generateHex();
+        } while (existingColorSet.contains(randomColor));
+
+        return randomColor;
+    }
+
+    private String generateHex() {
+        int r = 50 + RANDOM.nextInt(156); // 50 ~ 205 사이의 값
+        int g = 50 + RANDOM.nextInt(156);
+        int b = 50 + RANDOM.nextInt(156);
+
+        return String.format("#%02X%02X%02X", r, g, b);
+    }
+}

--- a/src/test/java/konkuk/kuit/baro/domain/category/repository/PinCategoryRepositoryTest.java
+++ b/src/test/java/konkuk/kuit/baro/domain/category/repository/PinCategoryRepositoryTest.java
@@ -47,7 +47,6 @@ class PinCategoryRepositoryTest {
                 .name("홍길동")
                 .password("qwer1234!")
                 .profileImage("image.png")
-                .color("0XFFFF")
                 .build();
 
         userRepository.save(user);

--- a/src/test/java/konkuk/kuit/baro/domain/pin/repository/PinRepositoryTest.java
+++ b/src/test/java/konkuk/kuit/baro/domain/pin/repository/PinRepositoryTest.java
@@ -35,7 +35,6 @@ class PinRepositoryTest {
                 .name("홍길동")
                 .password("qwer1234!")
                 .profileImage("image.png")
-                .color("0XFFFF")
                 .build();
 
         userRepository.save(user);

--- a/src/test/java/konkuk/kuit/baro/domain/promise/repository/PromiseAvailableTimeRepositoryTest.java
+++ b/src/test/java/konkuk/kuit/baro/domain/promise/repository/PromiseAvailableTimeRepositoryTest.java
@@ -51,7 +51,7 @@ class PromiseAvailableTimeRepositoryTest {
 
         promiseRepository.save(promise);
 
-        PromiseMember promiseMember = PromiseMember.createPromiseMember(true, user, promise);
+        PromiseMember promiseMember = PromiseMember.createPromiseMember(true, "#F4F4F4", user, promise);
 
         promiseMemberRepository.save(promiseMember);
     }

--- a/src/test/java/konkuk/kuit/baro/domain/promise/repository/PromiseAvailableTimeRepositoryTest.java
+++ b/src/test/java/konkuk/kuit/baro/domain/promise/repository/PromiseAvailableTimeRepositoryTest.java
@@ -38,7 +38,6 @@ class PromiseAvailableTimeRepositoryTest {
                 .name("홍길동")
                 .password("qwer1234!")
                 .profileImage("image.png")
-                .color("0XFFFF")
                 .build();
 
         userRepository.save(user);

--- a/src/test/java/konkuk/kuit/baro/domain/promise/repository/PromiseCandidateTimeRepositoryTest.java
+++ b/src/test/java/konkuk/kuit/baro/domain/promise/repository/PromiseCandidateTimeRepositoryTest.java
@@ -50,7 +50,6 @@ class PromiseCandidateTimeRepositoryTest {
                 .name("홍길동")
                 .password("qwer1234!")
                 .profileImage("image.png")
-                .color("0XFFFF")
                 .build();
 
         userRepository.save(user);

--- a/src/test/java/konkuk/kuit/baro/domain/promise/repository/PromiseCandidateTimeRepositoryTest.java
+++ b/src/test/java/konkuk/kuit/baro/domain/promise/repository/PromiseCandidateTimeRepositoryTest.java
@@ -63,7 +63,7 @@ class PromiseCandidateTimeRepositoryTest {
 
         Promise savedPromise = promiseRepository.save(promise);
 
-        PromiseMember promiseMember = PromiseMember.createPromiseMember(true, user, promise);
+        PromiseMember promiseMember = PromiseMember.createPromiseMember(true, "#F4F4F4", user, promise);
 
         promiseMemberRepository.save(promiseMember);
 

--- a/src/test/java/konkuk/kuit/baro/domain/promise/repository/PromiseMemberRepositoryTest.java
+++ b/src/test/java/konkuk/kuit/baro/domain/promise/repository/PromiseMemberRepositoryTest.java
@@ -36,7 +36,6 @@ class PromiseMemberRepositoryTest {
                 .name("홍길동")
                 .password("qwer1234!")
                 .profileImage("image.png")
-                .color("0XFFFF")
                 .build();
 
         userRepository.save(user);

--- a/src/test/java/konkuk/kuit/baro/domain/promise/repository/PromiseMemberRepositoryTest.java
+++ b/src/test/java/konkuk/kuit/baro/domain/promise/repository/PromiseMemberRepositoryTest.java
@@ -23,11 +23,15 @@ import static org.assertj.core.api.Assertions.*;
 @Transactional
 class PromiseMemberRepositoryTest {
 
-    @Autowired private PromiseMemberRepository promiseMemberRepository;
-    @Autowired private UserRepository userRepository;
-    @Autowired private PromiseRepository promiseRepository;
+    @Autowired
+    private PromiseMemberRepository promiseMemberRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private PromiseRepository promiseRepository;
 
-    @PersistenceContext private EntityManager em;
+    @PersistenceContext
+    private EntityManager em;
 
     @BeforeEach
     void init() {
@@ -58,7 +62,7 @@ class PromiseMemberRepositoryTest {
         Promise findPromise = promiseRepository.findById(1L).get();
 
         // when
-        PromiseMember promiseMember = PromiseMember.createPromiseMember(true, findUser, findPromise);
+        PromiseMember promiseMember = PromiseMember.createPromiseMember(true, "#F4F4F4", findUser, findPromise);
         promiseMemberRepository.save(promiseMember);
 
         em.flush();
@@ -76,7 +80,7 @@ class PromiseMemberRepositoryTest {
         User findUser = userRepository.findById(1L).get();
         Promise findPromise = promiseRepository.findById(1L).get();
 
-        PromiseMember promiseMember = PromiseMember.createPromiseMember(true, findUser, findPromise);
+        PromiseMember promiseMember = PromiseMember.createPromiseMember(true, "#F4F4F4", findUser, findPromise);
         promiseMemberRepository.save(promiseMember);
 
         em.flush();
@@ -101,7 +105,7 @@ class PromiseMemberRepositoryTest {
         User findUser = userRepository.findById(1L).get();
         Promise findPromise = promiseRepository.findById(1L).get();
 
-        PromiseMember promiseMember = PromiseMember.createPromiseMember(true, findUser, findPromise);
+        PromiseMember promiseMember = PromiseMember.createPromiseMember(true, "#F4F4F4", findUser, findPromise);
         promiseMemberRepository.save(promiseMember);
 
         em.flush();

--- a/src/test/java/konkuk/kuit/baro/domain/promise/repository/PromiseSuggestedPlaceRepositoryTest.java
+++ b/src/test/java/konkuk/kuit/baro/domain/promise/repository/PromiseSuggestedPlaceRepositoryTest.java
@@ -54,7 +54,7 @@ class PromiseSuggestedPlaceRepositoryTest {
 
         promiseRepository.save(promise);
 
-        PromiseMember promiseMember = PromiseMember.createPromiseMember(true, user, promise);
+        PromiseMember promiseMember = PromiseMember.createPromiseMember(true,"#F4F4F4", user, promise);
 
         promiseMemberRepository.save(promiseMember);
 

--- a/src/test/java/konkuk/kuit/baro/domain/promise/repository/PromiseSuggestedPlaceRepositoryTest.java
+++ b/src/test/java/konkuk/kuit/baro/domain/promise/repository/PromiseSuggestedPlaceRepositoryTest.java
@@ -41,7 +41,6 @@ class PromiseSuggestedPlaceRepositoryTest {
                 .name("홍길동")
                 .password("qwer1234!")
                 .profileImage("image.png")
-                .color("0XFFFF")
                 .build();
 
         userRepository.save(user);

--- a/src/test/java/konkuk/kuit/baro/domain/schedule/repository/ScheduleRepositoryTest.java
+++ b/src/test/java/konkuk/kuit/baro/domain/schedule/repository/ScheduleRepositoryTest.java
@@ -34,7 +34,6 @@ class ScheduleRepositoryTest {
                 .name("홍길동")
                 .password("qwer1234!")
                 .profileImage("image.png")
-                .color("0XFFFF")
                 .build();
 
         userRepository.save(user);

--- a/src/test/java/konkuk/kuit/baro/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/konkuk/kuit/baro/domain/user/repository/UserRepositoryTest.java
@@ -49,7 +49,6 @@ class UserRepositoryTest {
                 .name("홍길동")
                 .password("qwer1234!")
                 .profileImage("image.png")
-                .color("0XFFFF")
                 .build();
 
         userRepository.save(user);

--- a/src/test/java/konkuk/kuit/baro/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/konkuk/kuit/baro/domain/user/repository/UserRepositoryTest.java
@@ -28,7 +28,6 @@ class UserRepositoryTest {
                 .name("홍길동")
                 .password("qwer1234!")
                 .profileImage("image.png")
-                .color("0XFFFF")
                 .build();
 
         // when

--- a/src/test/java/konkuk/kuit/baro/domain/vote/repository/PromisePlaceVoteHistoryRepositoryTest.java
+++ b/src/test/java/konkuk/kuit/baro/domain/vote/repository/PromisePlaceVoteHistoryRepositoryTest.java
@@ -32,15 +32,23 @@ import static org.assertj.core.api.Assertions.*;
 @Transactional
 class PromisePlaceVoteHistoryRepositoryTest {
 
-    @Autowired private PromisePlaceVoteHistoryRepository promisePlaceVoteHistoryRepository;
-    @Autowired private PromiseRepository promiseRepository;
-    @Autowired private PromiseMemberRepository promiseMemberRepository;
-    @Autowired private UserRepository userRepository;
-    @Autowired private PromiseSuggestedPlaceRepository promiseSuggestedPlaceRepository;
-    @Autowired private PlaceRepository placeRepository;
-    @Autowired private PromiseVoteRepository promiseVoteRepository;
+    @Autowired
+    private PromisePlaceVoteHistoryRepository promisePlaceVoteHistoryRepository;
+    @Autowired
+    private PromiseRepository promiseRepository;
+    @Autowired
+    private PromiseMemberRepository promiseMemberRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private PromiseSuggestedPlaceRepository promiseSuggestedPlaceRepository;
+    @Autowired
+    private PlaceRepository placeRepository;
+    @Autowired
+    private PromiseVoteRepository promiseVoteRepository;
 
-    @PersistenceContext private EntityManager em;
+    @PersistenceContext
+    private EntityManager em;
 
     @BeforeEach
     void init() {
@@ -62,7 +70,7 @@ class PromisePlaceVoteHistoryRepositoryTest {
 
         promiseRepository.save(promise);
 
-        PromiseMember promiseMember = PromiseMember.createPromiseMember(true, user, promise);
+        PromiseMember promiseMember = PromiseMember.createPromiseMember(true, "#F4F4F4", user, promise);
 
         promiseMemberRepository.save(promiseMember);
 

--- a/src/test/java/konkuk/kuit/baro/domain/vote/repository/PromisePlaceVoteHistoryRepositoryTest.java
+++ b/src/test/java/konkuk/kuit/baro/domain/vote/repository/PromisePlaceVoteHistoryRepositoryTest.java
@@ -49,7 +49,6 @@ class PromisePlaceVoteHistoryRepositoryTest {
                 .name("홍길동")
                 .password("qwer1234!")
                 .profileImage("image.png")
-                .color("0XFFFF")
                 .build();
 
         userRepository.save(user);

--- a/src/test/java/konkuk/kuit/baro/domain/vote/repository/PromiseTimeVoteHistoryRepositoryTest.java
+++ b/src/test/java/konkuk/kuit/baro/domain/vote/repository/PromiseTimeVoteHistoryRepositoryTest.java
@@ -52,7 +52,6 @@ class PromiseTimeVoteHistoryRepositoryTest {
                 .name("홍길동")
                 .password("qwer1234!")
                 .profileImage("image.png")
-                .color("0XFFFF")
                 .build();
 
         userRepository.save(user);

--- a/src/test/java/konkuk/kuit/baro/domain/vote/repository/PromiseTimeVoteHistoryRepositoryTest.java
+++ b/src/test/java/konkuk/kuit/baro/domain/vote/repository/PromiseTimeVoteHistoryRepositoryTest.java
@@ -65,7 +65,7 @@ class PromiseTimeVoteHistoryRepositoryTest {
 
         promiseRepository.save(promise);
 
-        PromiseMember promiseMember = PromiseMember.createPromiseMember(true, user, promise);
+        PromiseMember promiseMember = PromiseMember.createPromiseMember(true, "#F4F4F4", user, promise);
 
         promiseMemberRepository.save(promiseMember);
 


### PR DESCRIPTION
## Related issue 🛠
- closed #22 

## Work Description 📝
- 테두리 색상 정보를 약속 참여자 테이블로 이동시켰습니다.
- ColorUtil 이라는 클래스를 만들었습니다. 이 클래스를 통해 랜덤한 #OOOOOO 형태의 색상값을 만들어주도록 하였고, 추가적으로 특정 약속에 참여한 참여자들간에는 색상이 겹칠 수 없도록 해두었습니다.

## Screenshot 📸

## Uncompleted Tasks 😅
- 없습니다

## To Reviewers 📢
