### PR TITLE
[Feat] 홈 화면 조회 

### DIFF
--- a/src/main/java/konkuk/kuit/baro/domain/promise/model/Promise.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/model/Promise.java
@@ -49,7 +49,7 @@ public class Promise extends BaseEntity {
     private LocalTime fixedEndTime;
 
     @Setter
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "place_id")
     private Place place;  // 확정된 장소
 

--- a/src/main/java/konkuk/kuit/baro/domain/promise/repository/PromiseMemberRepository.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/repository/PromiseMemberRepository.java
@@ -1,5 +1,6 @@
 package konkuk.kuit.baro.domain.promise.repository;
 
+import konkuk.kuit.baro.domain.promise.model.Promise;
 import konkuk.kuit.baro.domain.promise.model.PromiseMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -9,6 +10,19 @@ import java.util.List;
 
 @Repository
 public interface PromiseMemberRepository extends JpaRepository<PromiseMember, Long> {
+    List<PromiseMember> findAllByUserId(Long userId);
+    @Query("SELECT p FROM Promise p WHERE p.id = :promiseMemberId ")
+    Promise findByPromiseMemberId(Long promiseMemberId);
+
+    @Query("SELECT COUNT(*) FROM PromiseMember pm where pm.promise.id = :promiseId")
+    int findNumberOfPromiseMemberById(Long promiseId);
+
+    @Query(value = "SELECT u.name " +
+                   "FROM promise_member pm " +
+                   "JOIN users u ON pm.user_id = u.user_id " +
+                   "WHERE pm.promise_id = :promiseId AND pm.is_host = 1", nativeQuery = true)
+    String findHostNameByPromiseId(@Param("promiseId") Long promiseId);
+
 
     @Query("SELECT pm.color FROM PromiseMember pm WHERE pm.id = :promiseId")
     List<String> findColorsByPromiseId(Long promiseId);

--- a/src/main/java/konkuk/kuit/baro/domain/promise/repository/PromiseMemberRepository.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/repository/PromiseMemberRepository.java
@@ -1,6 +1,5 @@
 package konkuk.kuit.baro.domain.promise.repository;
 
-import konkuk.kuit.baro.domain.promise.model.Promise;
 import konkuk.kuit.baro.domain.promise.model.PromiseMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -11,9 +10,7 @@ import java.util.List;
 @Repository
 public interface PromiseMemberRepository extends JpaRepository<PromiseMember, Long> {
     List<PromiseMember> findAllByUserId(Long userId);
-    @Query("SELECT p FROM Promise p WHERE p.id = :promiseMemberId ")
-    Promise findByPromiseMemberId(Long promiseMemberId);
-
+    
     @Query("SELECT COUNT(*) FROM PromiseMember pm where pm.promise.id = :promiseId")
     int findNumberOfPromiseMemberById(Long promiseId);
 

--- a/src/main/java/konkuk/kuit/baro/domain/promise/repository/PromiseMemberRepository.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/repository/PromiseMemberRepository.java
@@ -3,6 +3,7 @@ package konkuk.kuit.baro.domain.promise.repository;
 import konkuk.kuit.baro.domain.promise.model.PromiseMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;

--- a/src/main/java/konkuk/kuit/baro/domain/promise/repository/PromiseRepository.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/repository/PromiseRepository.java
@@ -2,8 +2,12 @@ package konkuk.kuit.baro.domain.promise.repository;
 
 import konkuk.kuit.baro.domain.promise.model.Promise;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PromiseRepository extends JpaRepository<Promise, Long> {
+
+
 }

--- a/src/main/java/konkuk/kuit/baro/domain/user/controller/UserController.java
+++ b/src/main/java/konkuk/kuit/baro/domain/user/controller/UserController.java
@@ -2,21 +2,18 @@ package konkuk.kuit.baro.domain.user.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import konkuk.kuit.baro.domain.user.dto.request.UserUpdatePasswordRequestDTO;
 import konkuk.kuit.baro.domain.user.dto.request.UserUpdateProfileRequestDTO;
+import konkuk.kuit.baro.domain.user.dto.response.UserHomePageResponseDTO;
 import konkuk.kuit.baro.domain.user.dto.response.UserProfileResponseDTO;
 import konkuk.kuit.baro.domain.user.dto.response.UserProfileSettingResponseDTO;
 import konkuk.kuit.baro.domain.user.service.UserService;
 import konkuk.kuit.baro.global.common.annotation.CustomExceptionDescription;
-import konkuk.kuit.baro.global.common.config.swagger.SwaggerResponseDescription;
 import konkuk.kuit.baro.global.common.response.BaseResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-
-import java.time.format.DecimalStyle;
 
 import static konkuk.kuit.baro.global.common.config.swagger.SwaggerResponseDescription.*;
 
@@ -69,5 +66,13 @@ public class UserController {
     public BaseResponse<Void> delete(Long userId){
         userService.deleteUser(userId);
         return BaseResponse.ok(null);
+    }
+
+    @Tag(name = "Home Page", description = "홈 화면 API")
+    @Operation(summary = "홈 화면 조회", description = "메인 홈 화면을 조회합니다.")
+    @GetMapping()
+    @CustomExceptionDescription(USER_HOME)
+    public BaseResponse<UserHomePageResponseDTO> getHomePage(){
+        return BaseResponse.ok(userService.getHomePage(1L));
     }
 }

--- a/src/main/java/konkuk/kuit/baro/domain/user/dto/response/UserHomePagePromiseDTO.java
+++ b/src/main/java/konkuk/kuit/baro/domain/user/dto/response/UserHomePagePromiseDTO.java
@@ -1,0 +1,33 @@
+package konkuk.kuit.baro.domain.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserHomePagePromiseDTO {
+    @Schema(description = "약속 장소명", example = "스타벅스 건대입구점")
+    private String placeName;
+
+    @Schema(description = "약속명", example = "KUIT 2차 회의")
+    private String promiseName;
+
+    @Schema(description = "약속 날짜", example = "2/24")
+    private LocalDate promiseDate;
+
+    @Schema(description = "약속 날짜 요일", example = "토")
+    private String promiseDay;
+
+    @Schema(description = "약속 참여자", example = "이지환 외 2명")
+    private String promiseMember;
+
+    @Schema(description = "약속까지 남은 시간", example = "2")
+    private int promiseDday;
+}

--- a/src/main/java/konkuk/kuit/baro/domain/user/dto/response/UserHomePagePromiseDTO.java
+++ b/src/main/java/konkuk/kuit/baro/domain/user/dto/response/UserHomePagePromiseDTO.java
@@ -13,6 +13,9 @@ import java.time.LocalDate;
 @NoArgsConstructor
 @AllArgsConstructor
 public class UserHomePagePromiseDTO {
+    @Schema(description = "약속 ID", example = "1")
+    private Long promiseId;
+
     @Schema(description = "약속 장소명", example = "스타벅스 건대입구점")
     private String placeName;
 

--- a/src/main/java/konkuk/kuit/baro/domain/user/dto/response/UserHomePageResponseDTO.java
+++ b/src/main/java/konkuk/kuit/baro/domain/user/dto/response/UserHomePageResponseDTO.java
@@ -1,0 +1,29 @@
+package konkuk.kuit.baro.domain.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserHomePageResponseDTO {
+    @Schema(description = "이름", example = "이정연")
+    private String userName;
+
+    @Schema(description = "약속까지 남은 시간(가장 빠른 약속)", example = "2")
+    private Integer fastestDday;
+
+    List<UserHomePagePromiseDTO> promiseDTOs;
+
+    public UserHomePageResponseDTO(String userName) {
+        this.userName = userName;
+        this.fastestDday = null;
+        this.promiseDTOs = null;
+    }
+}

--- a/src/main/java/konkuk/kuit/baro/domain/user/service/UserService.java
+++ b/src/main/java/konkuk/kuit/baro/domain/user/service/UserService.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.format.TextStyle;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -114,7 +115,7 @@ public class UserService {
                 String hostName = promiseMemberRepository.findHostNameByPromiseId(promise.getId());
                 int numberOfPromiseMember = promiseMemberRepository.findNumberOfPromiseMemberById(promise.getId());
                 String promiseMembers = hostName + " 외 " + (numberOfPromiseMember - 1) + "명";
-                int Dday = promiseDate.getDayOfYear() - LocalDate.now().getDayOfYear();
+                int Dday = (int) ChronoUnit.DAYS.between(LocalDate.now(), promiseDate);
                 if(Dday < fastestDday){
                     fastestDday = Dday;
                 }

--- a/src/main/java/konkuk/kuit/baro/domain/user/service/UserService.java
+++ b/src/main/java/konkuk/kuit/baro/domain/user/service/UserService.java
@@ -108,23 +108,28 @@ public class UserService {
         List<UserHomePagePromiseDTO> promiseDTO = new ArrayList<>();
         int fastestDday = Integer.MIN_VALUE;
         for (PromiseMember promiseMember : findPromiseMember) {
+            log.info("Promise member: {}", promiseMember.getId());
             Promise promise = promiseMemberRepository.findByPromiseMemberId(promiseMember.getId());
-            LocalDate promiseDate = promise.getFixedDate();
-            String hostName = promiseMemberRepository.findHostNameByPromiseId(promise.getId());
-            int numberOfPromiseMember = promiseMemberRepository.findNumberOfPromiseMemberById(promise.getId());
-            String promiseMembers = hostName + "외 " + (numberOfPromiseMember - 1) + "명";
-            int Dday = promiseDate.getDayOfYear() - LocalDate.now().getDayOfYear();
-            if(Dday > fastestDday){
-                fastestDday = Dday;
+            if(promise != null){
+                log.info("Promise Name : {}", promise.getPromiseName());
+                LocalDate promiseDate = promise.getFixedDate();
+                String hostName = promiseMemberRepository.findHostNameByPromiseId(promise.getId());
+                int numberOfPromiseMember = promiseMemberRepository.findNumberOfPromiseMemberById(promise.getId());
+                String promiseMembers = hostName + " 외 " + (numberOfPromiseMember - 1) + "명";
+                int Dday = promiseDate.getDayOfYear() - LocalDate.now().getDayOfYear();
+                if(Dday > fastestDday){
+                    fastestDday = Dday;
+                }
+                promiseDTO.add(new UserHomePagePromiseDTO(
+                        promise.getPlace().getPlaceName(),
+                        promise.getPromiseName(),
+                        promise.getFixedDate(),
+                        promise.getFixedDate().getDayOfWeek().getDisplayName(TextStyle.FULL, Locale.KOREAN),
+                        promiseMembers,
+                        Dday
+                ));
             }
-            promiseDTO.add(new UserHomePagePromiseDTO(
-                    promise.getPlace().getPlaceName(),
-                    promise.getPromiseName(),
-                    promise.getFixedDate(),
-                    promise.getFixedDate().getDayOfWeek().getDisplayName(TextStyle.FULL, Locale.KOREAN),
-                    promiseMembers,
-                    Dday
-            ));
+
         }
 
         return new UserHomePageResponseDTO(loginUser.getName(), fastestDday, promiseDTO);

--- a/src/main/java/konkuk/kuit/baro/domain/user/service/UserService.java
+++ b/src/main/java/konkuk/kuit/baro/domain/user/service/UserService.java
@@ -106,18 +106,16 @@ public class UserService {
             return new UserHomePageResponseDTO(loginUser.getName()); // 사용자 이름만 반환
         }
         List<UserHomePagePromiseDTO> promiseDTO = new ArrayList<>();
-        int fastestDday = Integer.MIN_VALUE;
+        int fastestDday = Integer.MAX_VALUE;
         for (PromiseMember promiseMember : findPromiseMember) {
-            log.info("Promise member: {}", promiseMember.getId());
-            Promise promise = promiseMemberRepository.findByPromiseMemberId(promiseMember.getId());
+            Promise promise = promiseMember.getPromise();
             if(promise != null){
-                log.info("Promise Name : {}", promise.getPromiseName());
                 LocalDate promiseDate = promise.getFixedDate();
                 String hostName = promiseMemberRepository.findHostNameByPromiseId(promise.getId());
                 int numberOfPromiseMember = promiseMemberRepository.findNumberOfPromiseMemberById(promise.getId());
                 String promiseMembers = hostName + " 외 " + (numberOfPromiseMember - 1) + "명";
                 int Dday = promiseDate.getDayOfYear() - LocalDate.now().getDayOfYear();
-                if(Dday > fastestDday){
+                if(Dday < fastestDday){
                     fastestDday = Dday;
                 }
                 promiseDTO.add(new UserHomePagePromiseDTO(

--- a/src/main/java/konkuk/kuit/baro/domain/user/service/UserService.java
+++ b/src/main/java/konkuk/kuit/baro/domain/user/service/UserService.java
@@ -120,6 +120,7 @@ public class UserService {
                     fastestDday = Dday;
                 }
                 promiseDTO.add(new UserHomePagePromiseDTO(
+                        promise.getId(),
                         promise.getPlace().getPlaceName(),
                         promise.getPromiseName(),
                         promise.getFixedDate(),

--- a/src/main/java/konkuk/kuit/baro/global/common/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/kuit/baro/global/common/config/swagger/SwaggerResponseDescription.java
@@ -28,6 +28,9 @@ public enum SwaggerResponseDescription {
     USER_DELETE(new LinkedHashSet<>(Set.of(
             USER_NOT_FOUND
     ))),
+    USER_HOME(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND
+    ))),
 
     //Promise
     PROMISE_SUGGEST(new LinkedHashSet<>(Set.of(

--- a/src/main/java/konkuk/kuit/baro/global/common/response/status/ErrorCode.java
+++ b/src/main/java/konkuk/kuit/baro/global/common/response/status/ErrorCode.java
@@ -30,6 +30,8 @@ public enum ErrorCode implements ResponseStatus {
     INVALID_SCHEDULE_TIME(302, BAD_REQUEST.value(), "시작 시간과 종료 시간이 동일할 수 없습니다."),
     SCHEDULE_NOT_FOUND(303, HttpStatus.NOT_FOUND.value(), "존재하지 않는 일정입니다."),
     SCHEDULE_NOT_EXISTS(304, HttpStatus.NOT_FOUND.value(), "등록된 일정이 없습니다.");
+
+    //Promise
     @Getter
     private final int code;
     private final int httpStatus;


### PR DESCRIPTION
## Related issue 🛠
- closed #21

## Work Description 📝
- 홈 화면 조회 기능 구현 (약속이 있는 경우, 없는 경우 구분)
- Place <-> Promise 간 연관관계를 1 : N 으로 수정하였습니다.

## Screenshot 📸
<img src="" width="360"/>

## Uncompleted Tasks 😅

## To Reviewers 📢
현재 로그인한 사용자가 속해 있는 약속을 가져오고 싶을 때, user_id로부터 PromiseMember를 찾고 PromiseMember로부터 쿼리를 통해 Promise를 찾는 방법을 처음에 사용했는데 PromiseMember에서 Promise 객체를 찾는 것이다 보니 어떤 케이스에서는 이 쿼리가 null을 반환할 때도 있어서, 단순하게 Getter를 사용했습니다.