### PR TITLE
[Feat] 약속 관리시 필요한 약속 리스트 반환 기능 구현 

### DIFF
--- a/src/main/java/konkuk/kuit/baro/domain/promise/controller/PromiseController.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/controller/PromiseController.java
@@ -33,6 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.locationtech.jts.geom.Coordinate;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -92,5 +93,13 @@ public class PromiseController {
     public BaseResponse<PendingPromiseResponseDTO> getPendingPromise(@PathVariable("promiseId") Long promiseId,
                                                                      @RequestParam("isHost") Boolean isHost) {
         return BaseResponse.ok(promiseService.getPendingPromise(promiseId, isHost));
+    }
+
+    @Tag(name = "약속 관리 페이지 API", description = "약속 제안 관련 API")
+    @Operation(summary = "약속 관리 페이지", description = "약속 관리 페이지에 필요한 데이터를 반환합니다.")
+    @GetMapping("/management")
+    // @CustomExceptionDescription(PROMISE_MANAGING_PAGE)
+    public BaseResponse<PromiseManagementResponseDTO> getPromiseManagementPage(@Valid @RequestBody PromiseManagementRequestDTO request) {
+        return BaseResponse.ok(promiseService.getPromiseManagementData(request, 1L));
     }
 }

--- a/src/main/java/konkuk/kuit/baro/domain/promise/controller/PromiseController.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/controller/PromiseController.java
@@ -99,7 +99,7 @@ public class PromiseController {
     @Tag(name = "약속 관리 페이지 API", description = "약속 제안 관련 API")
     @Operation(summary = "약속 관리 페이지", description = "약속 관리 페이지에 필요한 데이터를 반환합니다.")
     @GetMapping("/management")
-    // @CustomExceptionDescription(PROMISE_MANAGING_PAGE)
+    @CustomExceptionDescription(PROMISE_MANAGING_PAGE)
     public BaseResponse<PromiseManagementResponseDTO> getPromiseManagementPage() {
         return BaseResponse.ok(promiseService.getPromiseManagementData(1L, true));
     }
@@ -107,7 +107,7 @@ public class PromiseController {
     @Tag(name = "호스트의 약속 관리 페이지 API", description = "약속 제안 관련 API")
     @Operation(summary = "호스트의 약속 관리 페이지", description = "호스트가 약속 관리 페이지에 필요한 데이터를 반환합니다.")
     @GetMapping("/management/host")
-    // @CustomExceptionDescription(HOST_PROMISE_MANAGING_PAGE)
+    @CustomExceptionDescription(HOST_PROMISE_MANAGING_PAGE)
     public BaseResponse<PromiseManagementResponseDTO> getHostPromiseManagementPage() {
         return BaseResponse.ok(promiseService.getPromiseManagementData(1L, false));
     }

--- a/src/main/java/konkuk/kuit/baro/domain/promise/controller/PromiseController.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/controller/PromiseController.java
@@ -101,14 +101,14 @@ public class PromiseController {
     @GetMapping("/management")
     // @CustomExceptionDescription(PROMISE_MANAGING_PAGE)
     public BaseResponse<PromiseManagementResponseDTO> getPromiseManagementPage() {
-        return BaseResponse.ok(promiseService.getPromiseManagementData(1L));
+        return BaseResponse.ok(promiseService.getPromiseManagementData(1L, true));
     }
 
     @Tag(name = "호스트의 약속 관리 페이지 API", description = "약속 제안 관련 API")
     @Operation(summary = "호스트의 약속 관리 페이지", description = "호스트가 약속 관리 페이지에 필요한 데이터를 반환합니다.")
     @GetMapping("/management/host")
-    // @CustomExceptionDescription(PROMISE_MANAGING_PAGE)
+    // @CustomExceptionDescription(HOST_PROMISE_MANAGING_PAGE)
     public BaseResponse<PromiseManagementResponseDTO> getHostPromiseManagementPage() {
-        return BaseResponse.ok(promiseService.getHostPromiseManagementData(1L));
+        return BaseResponse.ok(promiseService.getPromiseManagementData(1L, false));
     }
 }

--- a/src/main/java/konkuk/kuit/baro/domain/promise/controller/PromiseController.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/controller/PromiseController.java
@@ -20,6 +20,7 @@ import konkuk.kuit.baro.domain.promise.repository.PromiseMemberRepository;
 import konkuk.kuit.baro.domain.promise.repository.PromiseRepository;
 import konkuk.kuit.baro.domain.promise.repository.PromiseSuggestedPlaceRepository;
 import konkuk.kuit.baro.domain.promise.service.PromiseAvailableTimeService;
+import konkuk.kuit.baro.domain.promise.dto.response.PromiseManagementResponseDTO;
 import konkuk.kuit.baro.domain.promise.service.PromiseService;
 import konkuk.kuit.baro.domain.user.model.User;
 import konkuk.kuit.baro.domain.user.repository.UserRepository;
@@ -99,7 +100,7 @@ public class PromiseController {
     @Operation(summary = "약속 관리 페이지", description = "약속 관리 페이지에 필요한 데이터를 반환합니다.")
     @GetMapping("/management")
     // @CustomExceptionDescription(PROMISE_MANAGING_PAGE)
-    public BaseResponse<PromiseManagementResponseDTO> getPromiseManagementPage(@Valid @RequestBody PromiseManagementRequestDTO request) {
-        return BaseResponse.ok(promiseService.getPromiseManagementData(request, 1L));
+    public BaseResponse<PromiseManagementResponseDTO> getPromiseManagementPage() {
+        return BaseResponse.ok(promiseService.getPromiseManagementData(1L));
     }
 }

--- a/src/main/java/konkuk/kuit/baro/domain/promise/controller/PromiseController.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/controller/PromiseController.java
@@ -100,15 +100,9 @@ public class PromiseController {
     @Operation(summary = "약속 관리 페이지", description = "약속 관리 페이지에 필요한 데이터를 반환합니다.")
     @GetMapping("/management")
     @CustomExceptionDescription(PROMISE_MANAGING_PAGE)
-    public BaseResponse<PromiseManagementResponseDTO> getPromiseManagementPage() {
-        return BaseResponse.ok(promiseService.getPromiseManagementData(1L, true));
-    }
-
-    @Tag(name = "호스트의 약속 관리 페이지 API", description = "약속 제안 관련 API")
-    @Operation(summary = "호스트의 약속 관리 페이지", description = "호스트가 약속 관리 페이지에 필요한 데이터를 반환합니다.")
-    @GetMapping("/management/host")
-    @CustomExceptionDescription(HOST_PROMISE_MANAGING_PAGE)
-    public BaseResponse<PromiseManagementResponseDTO> getHostPromiseManagementPage() {
-        return BaseResponse.ok(promiseService.getPromiseManagementData(1L, false));
+    public BaseResponse<PromiseManagementResponseDTO> getPromiseManagementPage(
+            @RequestParam(value = "isHost", required = true) boolean isHost
+    ) {
+        return BaseResponse.ok(promiseService.getPromiseManagementData(3L, isHost));
     }
 }

--- a/src/main/java/konkuk/kuit/baro/domain/promise/controller/PromiseController.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/controller/PromiseController.java
@@ -103,4 +103,12 @@ public class PromiseController {
     public BaseResponse<PromiseManagementResponseDTO> getPromiseManagementPage() {
         return BaseResponse.ok(promiseService.getPromiseManagementData(1L));
     }
+
+    @Tag(name = "호스트의 약속 관리 페이지 API", description = "약속 제안 관련 API")
+    @Operation(summary = "호스트의 약속 관리 페이지", description = "호스트가 약속 관리 페이지에 필요한 데이터를 반환합니다.")
+    @GetMapping("/management/host")
+    // @CustomExceptionDescription(PROMISE_MANAGING_PAGE)
+    public BaseResponse<PromiseManagementResponseDTO> getHostPromiseManagementPage() {
+        return BaseResponse.ok(promiseService.getHostPromiseManagementData(1L));
+    }
 }

--- a/src/main/java/konkuk/kuit/baro/domain/promise/dto/response/ConfirmedPromiseResponseDTO.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/dto/response/ConfirmedPromiseResponseDTO.java
@@ -1,10 +1,7 @@
 package konkuk.kuit.baro.domain.promise.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -13,6 +10,7 @@ import java.util.List;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 public class ConfirmedPromiseResponseDTO {
     @Schema(description = "약속 ID", example = "1")
     private Long promiseId;

--- a/src/main/java/konkuk/kuit/baro/domain/promise/dto/response/ConfirmedPromiseResponseDTO.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/dto/response/ConfirmedPromiseResponseDTO.java
@@ -1,0 +1,31 @@
+package konkuk.kuit.baro.domain.promise.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ConfirmedPromiseResponseDTO {
+    @Schema(description = "약속 ID", example = "1")
+    private Long promiseId;
+
+    @Schema(description = "약속명", example = "BARO 회의")
+    private String promiseName;
+
+    @Schema(description = "확정 인원 이름", example = "김상균, 이정연, 신종윤")
+    private List<String> promiseMembersNames;
+
+    @Schema(description = "약속 확정된 장소명", example = "건대입구역")
+    private String placeName;
+
+    @Schema(description = "약속 확정된 날짜", example = "2025-01-01")
+    private LocalDate fixedDate;
+}

--- a/src/main/java/konkuk/kuit/baro/domain/promise/dto/response/PromiseManagementResponseDTO.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/dto/response/PromiseManagementResponseDTO.java
@@ -1,9 +1,15 @@
 package konkuk.kuit.baro.domain.promise.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
 
 import java.util.List;
 
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
 public class PromiseManagementResponseDTO {
     @Schema(description = "제안된 약속들")
     private List<SuggestedPromiseResponseDTO> suggestedPromises;

--- a/src/main/java/konkuk/kuit/baro/domain/promise/dto/response/PromiseManagementResponseDTO.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/dto/response/PromiseManagementResponseDTO.java
@@ -1,0 +1,17 @@
+package konkuk.kuit.baro.domain.promise.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public class PromiseManagementResponseDTO {
+    @Schema(description = "제안된 약속들")
+    private List<SuggestedPromiseResponseDTO> suggestedPromises;
+
+    @Schema(description = "투표중인 약속들")
+    private List<VotingPromiseResponseDTO> votingPromises;
+
+    @Schema(description = "확정된 약속들")
+    private List<ConfirmedPromiseResponseDTO> confirmedPromises;
+
+}

--- a/src/main/java/konkuk/kuit/baro/domain/promise/dto/response/SuggestedPromiseResponseDTO.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/dto/response/SuggestedPromiseResponseDTO.java
@@ -1,0 +1,33 @@
+package konkuk.kuit.baro.domain.promise.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SuggestedPromiseResponseDTO {
+    @Schema(description = "약속 ID", example = "1")
+    private Long promiseId;
+
+    @Schema(description = "약속명", example = "BARO 회의")
+    private String promiseName;
+
+    @Schema(description = "투표까지의 기한", example = "3")
+    private int untilDate;
+
+    @Schema(description = "약속 제안 지역", example = "BARO 회의")
+    private String suggestedRegion;
+
+    @Schema(description = "약속 시작 날짜", example = "2025-01-01")
+    private LocalDate startDate;
+
+    @Schema(description = "약속 끝 시간", example = "2025-01-02")
+    private LocalDate endDate;
+}

--- a/src/main/java/konkuk/kuit/baro/domain/promise/dto/response/SuggestedPromiseResponseDTO.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/dto/response/SuggestedPromiseResponseDTO.java
@@ -1,10 +1,7 @@
 package konkuk.kuit.baro.domain.promise.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDate;
 
@@ -12,6 +9,7 @@ import java.time.LocalDate;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 public class SuggestedPromiseResponseDTO {
     @Schema(description = "약속 ID", example = "1")
     private Long promiseId;

--- a/src/main/java/konkuk/kuit/baro/domain/promise/dto/response/VotingPromiseResponseDTO.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/dto/response/VotingPromiseResponseDTO.java
@@ -12,15 +12,15 @@ import java.time.LocalDate;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-public class SuggestedPromiseResponseDTO {
+public class VotingPromiseResponseDTO {
     @Schema(description = "약속 ID", example = "1")
     private Long promiseId;
 
     @Schema(description = "약속명", example = "BARO 회의")
     private String promiseName;
 
-    @Schema(description = "투표까지의 기한", example = "3")
-    private int untilVoteDate;
+    @Schema(description = "투표종료까지의 기한", example = "3")
+    private int untilVoteEndDate;
 
     @Schema(description = "약속 제안된 지역", example = "건대입구 주변")
     private String suggestedRegion;

--- a/src/main/java/konkuk/kuit/baro/domain/promise/dto/response/VotingPromiseResponseDTO.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/dto/response/VotingPromiseResponseDTO.java
@@ -1,10 +1,7 @@
 package konkuk.kuit.baro.domain.promise.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDate;
 
@@ -12,6 +9,7 @@ import java.time.LocalDate;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 public class VotingPromiseResponseDTO {
     @Schema(description = "약속 ID", example = "1")
     private Long promiseId;

--- a/src/main/java/konkuk/kuit/baro/domain/promise/repository/PromiseMemberRepository.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/repository/PromiseMemberRepository.java
@@ -29,15 +29,6 @@ public interface PromiseMemberRepository extends JpaRepository<PromiseMember, Lo
     @Query("SELECT pm.color FROM PromiseMember pm WHERE pm.id = :promiseId")
     List<String> findColorsByPromiseId(Long promiseId);
 
-    @Query("SELECT DISTINCT p FROM Promise p " +
-            "JOIN FETCH p.promiseMembers pm " +
-            "LEFT JOIN FETCH p.place " +
-            "WHERE pm.user.id = :userId " +
-            "AND (:isHost IS NULL OR pm.isHost = :isHost)")
-    List<Promise> findByUserIdAndHost(
-            @Param("userId") Long userId,
-            @Param("isHost") Boolean isHost);
-
     @Query("SELECT pm.user.name FROM PromiseMember pm WHERE pm.promise.id = :promiseId")
     List<String> findMemberNamesByPromiseId(@Param("promiseId") Long promiseId);
 

--- a/src/main/java/konkuk/kuit/baro/domain/promise/repository/PromiseMemberRepository.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/repository/PromiseMemberRepository.java
@@ -1,6 +1,7 @@
 package konkuk.kuit.baro.domain.promise.repository;
 
 import konkuk.kuit.baro.domain.promise.dto.response.PromiseMemberDTO;
+import konkuk.kuit.baro.domain.promise.model.Promise;
 import konkuk.kuit.baro.domain.promise.model.PromiseMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -27,6 +28,9 @@ public interface PromiseMemberRepository extends JpaRepository<PromiseMember, Lo
 
     @Query("SELECT pm.color FROM PromiseMember pm WHERE pm.id = :promiseId")
     List<String> findColorsByPromiseId(Long promiseId);
+
+    @Query("SELECT pm.promise FROM PromiseMember pm JOIN FETCH pm.promise WHERE pm.user.id = :userId")
+    List<Promise> findWithPromiseByUserId(@Param("userId") Long userId);
 
     @Query("SELECT new konkuk.kuit.baro.domain.promise.dto.response." +
            "PromiseMemberDTO(pm.user.id,pm.user.profileImage) " +

--- a/src/main/java/konkuk/kuit/baro/domain/promise/repository/PromiseMemberRepository.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/repository/PromiseMemberRepository.java
@@ -32,6 +32,9 @@ public interface PromiseMemberRepository extends JpaRepository<PromiseMember, Lo
     @Query("SELECT pm.promise FROM PromiseMember pm JOIN FETCH pm.promise WHERE pm.user.id = :userId")
     List<Promise> findWithPromiseByUserId(@Param("userId") Long userId);
 
+    @Query("SELECT pm.promise FROM PromiseMember pm JOIN FETCH pm.promise WHERE pm.user.id = :userId AND pm.isHost = true")
+    List<Promise> findWithPromiseByUserIdAndIsHost(@Param("userId") Long userId);
+
     @Query("SELECT pm.user.name FROM PromiseMember pm WHERE pm.promise.id = :promiseId")
     List<String> findMemberNamesByPromiseId(@Param("promiseId") Long promiseId);
 

--- a/src/main/java/konkuk/kuit/baro/domain/promise/repository/PromiseMemberRepository.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/repository/PromiseMemberRepository.java
@@ -30,8 +30,8 @@ public interface PromiseMemberRepository extends JpaRepository<PromiseMember, Lo
     List<String> findColorsByPromiseId(Long promiseId);
 
     @Query("SELECT pm.promise FROM PromiseMember pm " +
-            "JOIN FETCH pm.promise p " +
-            "LEFT JOIN FETCH p.place " +
+            "JOIN FETCH pm.promise " +
+            "LEFT JOIN FETCH pm.promise.place " +
             "WHERE pm.user.id = :userId " +
             "AND (:isHost IS NULL OR pm.isHost = :isHost)")
     List<Promise> findWithPromiseByUserId(

--- a/src/main/java/konkuk/kuit/baro/domain/promise/repository/PromiseMemberRepository.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/repository/PromiseMemberRepository.java
@@ -29,12 +29,12 @@ public interface PromiseMemberRepository extends JpaRepository<PromiseMember, Lo
     @Query("SELECT pm.color FROM PromiseMember pm WHERE pm.id = :promiseId")
     List<String> findColorsByPromiseId(Long promiseId);
 
-    @Query("SELECT pm.promise FROM PromiseMember pm " +
-            "JOIN FETCH pm.promise " +
-            "LEFT JOIN FETCH pm.promise.place " +
+    @Query("SELECT DISTINCT p FROM Promise p " +
+            "JOIN FETCH p.promiseMembers pm " +
+            "LEFT JOIN FETCH p.place " +
             "WHERE pm.user.id = :userId " +
             "AND (:isHost IS NULL OR pm.isHost = :isHost)")
-    List<Promise> findWithPromiseByUserId(
+    List<Promise> findByUserIdAndHost(
             @Param("userId") Long userId,
             @Param("isHost") Boolean isHost);
 

--- a/src/main/java/konkuk/kuit/baro/domain/promise/repository/PromiseMemberRepository.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/repository/PromiseMemberRepository.java
@@ -29,11 +29,14 @@ public interface PromiseMemberRepository extends JpaRepository<PromiseMember, Lo
     @Query("SELECT pm.color FROM PromiseMember pm WHERE pm.id = :promiseId")
     List<String> findColorsByPromiseId(Long promiseId);
 
-    @Query("SELECT pm.promise FROM PromiseMember pm JOIN FETCH pm.promise WHERE pm.user.id = :userId")
-    List<Promise> findWithPromiseByUserId(@Param("userId") Long userId);
-
-    @Query("SELECT pm.promise FROM PromiseMember pm JOIN FETCH pm.promise WHERE pm.user.id = :userId AND pm.isHost = true")
-    List<Promise> findWithPromiseByUserIdAndIsHost(@Param("userId") Long userId);
+    @Query("SELECT pm.promise FROM PromiseMember pm " +
+            "JOIN FETCH pm.promise p " +
+            "LEFT JOIN FETCH p.place " +
+            "WHERE pm.user.id = :userId " +
+            "AND (:isHost IS NULL OR pm.isHost = :isHost)")
+    List<Promise> findWithPromiseByUserId(
+            @Param("userId") Long userId,
+            @Param("isHost") Boolean isHost);
 
     @Query("SELECT pm.user.name FROM PromiseMember pm WHERE pm.promise.id = :promiseId")
     List<String> findMemberNamesByPromiseId(@Param("promiseId") Long promiseId);

--- a/src/main/java/konkuk/kuit/baro/domain/promise/repository/PromiseMemberRepository.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/repository/PromiseMemberRepository.java
@@ -32,6 +32,9 @@ public interface PromiseMemberRepository extends JpaRepository<PromiseMember, Lo
     @Query("SELECT pm.promise FROM PromiseMember pm JOIN FETCH pm.promise WHERE pm.user.id = :userId")
     List<Promise> findWithPromiseByUserId(@Param("userId") Long userId);
 
+    @Query("SELECT pm.user.name FROM PromiseMember pm WHERE pm.promise.id = :promiseId")
+    List<String> findMemberNamesByPromiseId(@Param("promiseId") Long promiseId);
+
     @Query("SELECT new konkuk.kuit.baro.domain.promise.dto.response." +
            "PromiseMemberDTO(pm.user.id,pm.user.profileImage) " +
            "FROM PromiseMember pm WHERE pm.promise.id = :promiseId")

--- a/src/main/java/konkuk/kuit/baro/domain/promise/repository/PromiseMemberRepository.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/repository/PromiseMemberRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface PromiseMemberRepository extends JpaRepository<PromiseMember, Long> {
@@ -30,7 +31,7 @@ public interface PromiseMemberRepository extends JpaRepository<PromiseMember, Lo
     List<String> findColorsByPromiseId(Long promiseId);
 
     @Query("SELECT pm.user.name FROM PromiseMember pm WHERE pm.promise.id = :promiseId")
-    List<String> findMemberNamesByPromiseId(@Param("promiseId") Long promiseId);
+    Optional<List<String>> findMemberNamesByPromiseId(@Param("promiseId") Long promiseId);
 
     @Query("SELECT new konkuk.kuit.baro.domain.promise.dto.response." +
            "PromiseMemberDTO(pm.user.id,pm.user.profileImage) " +

--- a/src/main/java/konkuk/kuit/baro/domain/promise/repository/PromiseRepository.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/repository/PromiseRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface PromiseRepository extends JpaRepository<Promise, Long> {
@@ -18,7 +19,7 @@ public interface PromiseRepository extends JpaRepository<Promise, Long> {
             "LEFT JOIN FETCH p.place " +
             "WHERE pm.user.id = :userId " +
             "AND (:isHost IS NULL OR pm.isHost = :isHost)")
-    List<Promise> findByUserIdAndHost(
+    Optional<List<Promise>> findByUserIdAndHost(
             @Param("userId") Long userId,
             @Param("isHost") Boolean isHost);
 }

--- a/src/main/java/konkuk/kuit/baro/domain/promise/repository/PromiseRepository.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/repository/PromiseRepository.java
@@ -6,9 +6,19 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface PromiseRepository extends JpaRepository<Promise, Long> {
 
     boolean existsById(Long promiseId);
 
+    @Query("SELECT DISTINCT p FROM Promise p " +
+            "JOIN FETCH p.promiseMembers pm " +
+            "LEFT JOIN FETCH p.place " +
+            "WHERE pm.user.id = :userId " +
+            "AND (:isHost IS NULL OR pm.isHost = :isHost)")
+    List<Promise> findByUserIdAndHost(
+            @Param("userId") Long userId,
+            @Param("isHost") Boolean isHost);
 }

--- a/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
@@ -91,6 +91,23 @@ public class PromiseService {
 
     private User findLoginUser(Long userId) {
         return userRepository.findById(userId)
+    @Transactional
+    public PromiseManagementResponseDTO getPromiseManagementData(PromiseManagementRequestDTO request, Long loginUserId){
+        User loginUser = findLoginUser(loginUserId);
+
+        // 사용자 ID를 기준으로 본인이 속한 Promise 목록 조회 (fetch join 사용)
+        List<Promise> myPromiseList = promiseMemberRepository.findWithPromiseByUserId(loginUser.getId());
+
+        // DTO 변환
+        List<PromiseResponseDTO> promiseDTOList = myPromiseList.stream()
+                .map(promise -> new PromiseResponseDTO(promise.getId(), promise.getPromiseName(), promise.getSuggestedStartDate(), promise.getSuggestedEndDate(), promise.getFixedDate()))
+                .collect(Collectors.toList());
+
+        return new PromiseManagementResponseDTO(promiseDTOList);
+    }
+
+    private User findLoginUser(Long loginUserId) {
+        return userRepository.findById(loginUserId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
     }
 

--- a/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
@@ -101,7 +101,7 @@ public class PromiseService {
     private User findLoginUser(Long userId) {
         return userRepository.findById(userId)
     @Transactional
-    public PromiseManagementResponseDTO getPromiseManagementData(PromiseManagementRequestDTO request, Long loginUserId){
+    public PromiseManagementResponseDTO getPromiseManagementData(Long loginUserId){
         User loginUser = findLoginUser(loginUserId);
 
         // 사용자 ID를 기준으로 본인이 속한 Promise 목록 조회 (fetch join 사용)

--- a/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
@@ -21,6 +21,7 @@ import konkuk.kuit.baro.global.common.exception.CustomException;
 import konkuk.kuit.baro.global.common.response.status.BaseStatus;
 import konkuk.kuit.baro.global.common.response.status.ErrorCode;
 import konkuk.kuit.baro.global.common.util.ColorUtil;
+import konkuk.kuit.baro.global.common.util.DateUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -129,7 +130,7 @@ public class PromiseService {
         return new SuggestedPromiseResponseDTO(
                 promise.getId(),
                 promise.getPromiseName(),
-                calculateDday(promise.getSuggestedEndDate()),
+                DateUtil.calculateDday(promise.getSuggestedEndDate()),
                 promise.getSuggestedRegion(),
                 promise.getSuggestedStartDate(),
                 promise.getSuggestedEndDate()
@@ -140,7 +141,7 @@ public class PromiseService {
         return new VotingPromiseResponseDTO(
                 promise.getId(),
                 promise.getPromiseName(),
-                calculateDday(promise.getSuggestedEndDate()),
+                DateUtil.calculateDday(promise.getSuggestedEndDate()),
                 promise.getSuggestedRegion(),
                 promise.getSuggestedStartDate(),
                 promise.getSuggestedEndDate()

--- a/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
@@ -104,7 +104,7 @@ public class PromiseService {
     @Transactional
     public PromiseManagementResponseDTO getPromiseManagementData(Long loginUserId, boolean isHost) {
         User loginUser = findLoginUser(loginUserId);
-        List<Promise> myPromiseList = promiseMemberRepository.findWithPromiseByUserId(loginUser.getId(), isHost);
+        List<Promise> myPromiseList = promiseMemberRepository.findByUserIdAndHost(loginUser.getId(), isHost);
         if( myPromiseList == null){myPromiseList = new ArrayList<>();}  // null일 경우 빈 리스트 반환
 
         List<SuggestedPromiseResponseDTO> suggestedPromises = new ArrayList<>();

--- a/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
@@ -251,15 +251,7 @@ public class PromiseService {
         return (int) ChronoUnit.DAYS.between(LocalDate.now(), endDate);
     }
 
-    private List<String> getPromiseMembersName(Long promiseId){
-        List<PromiseMember> promiseMembers = promiseMemberRepository.findAllByPromiseId(promiseId);
-
-        if (promiseMembers == null || promiseMembers.isEmpty()) {
-            return Collections.emptyList();
-        }
-
-        return promiseMembers.stream()
-                .map(promiseMember -> promiseMember.getUser().getName())
-                .collect(Collectors.toList());
+    private List<String> getPromiseMembersName(Long promiseId) {
+        return promiseMemberRepository.findMemberNamesByPromiseId(promiseId);
     }
 }

--- a/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
@@ -4,7 +4,6 @@ import konkuk.kuit.baro.domain.promise.dto.request.PromiseSuggestRequestDTO;
 import konkuk.kuit.baro.domain.promise.dto.response.PendingPromiseResponseDTO;
 import konkuk.kuit.baro.domain.promise.dto.response.PromiseMemberSuggestStateDTO;
 import konkuk.kuit.baro.domain.promise.dto.response.PromiseStatusResponseDTO;
-import konkuk.kuit.baro.domain.promise.dto.response.SuggestionProgress;
 import konkuk.kuit.baro.domain.promise.dto.response.ConfirmedPromiseResponseDTO;
 import konkuk.kuit.baro.domain.promise.dto.response.PromiseManagementResponseDTO;
 import konkuk.kuit.baro.domain.promise.dto.response.SuggestedPromiseResponseDTO;
@@ -18,7 +17,6 @@ import konkuk.kuit.baro.domain.promise.repository.PromiseSuggestedPlaceRepositor
 import konkuk.kuit.baro.domain.user.model.User;
 import konkuk.kuit.baro.domain.user.repository.UserRepository;
 import konkuk.kuit.baro.global.common.exception.CustomException;
-import konkuk.kuit.baro.global.common.response.status.BaseStatus;
 import konkuk.kuit.baro.global.common.response.status.ErrorCode;
 import konkuk.kuit.baro.global.common.util.ColorUtil;
 import konkuk.kuit.baro.global.common.util.DateUtil;
@@ -27,13 +25,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static konkuk.kuit.baro.domain.promise.dto.response.SuggestionProgress.*;
 
@@ -101,8 +95,6 @@ public class PromiseService {
         return new PendingPromiseResponseDTO(promiseName, null, promiseMembersSuggestState);
     }
 
-    private User findLoginUser(Long userId) {
-        return userRepository.findById(userId)
     @Transactional
     public PromiseManagementResponseDTO getPromiseManagementData(Long loginUserId, boolean isHost) {
         User loginUser = findLoginUser(loginUserId);
@@ -158,8 +150,8 @@ public class PromiseService {
         );
     }
 
-    private User findLoginUser(Long loginUserId) {
-        return userRepository.findById(loginUserId)
+    private User findLoginUser(Long userId) {
+        return userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
     }
 
@@ -194,7 +186,6 @@ public class PromiseService {
 
         return promiseMemberRepository.findAllByPromiseId(promiseId);
     }
-
 
     private boolean userIsExist(Long userId) {
         return userRepository.existsById(userId);
@@ -255,11 +246,6 @@ public class PromiseService {
                         extractSuggestionProgress(promiseMember.getId()),
                         promiseMember.getIsHost(), promiseMember.extractProfileImage())
                 ).toList();
-    }
-
-
-    private int calculateDday(LocalDate endDate) {
-        return (int) ChronoUnit.DAYS.between(LocalDate.now(), endDate);
     }
 
     private List<String> getPromiseMembersName(Long promiseId) {

--- a/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
@@ -104,7 +104,7 @@ public class PromiseService {
     @Transactional
     public PromiseManagementResponseDTO getPromiseManagementData(Long loginUserId, boolean isHost) {
         User loginUser = findLoginUser(loginUserId);
-        List<Promise> myPromiseList = promiseMemberRepository.findByUserIdAndHost(loginUser.getId(), isHost);
+        List<Promise> myPromiseList = promiseRepository.findByUserIdAndHost(loginUser.getId(), isHost);
         if( myPromiseList == null){myPromiseList = new ArrayList<>();}  // null일 경우 빈 리스트 반환
 
         List<SuggestedPromiseResponseDTO> suggestedPromises = new ArrayList<>();

--- a/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
@@ -105,6 +105,7 @@ public class PromiseService {
     public PromiseManagementResponseDTO getPromiseManagementData(Long loginUserId, boolean isHost) {
         User loginUser = findLoginUser(loginUserId);
         List<Promise> myPromiseList = promiseMemberRepository.findWithPromiseByUserId(loginUser.getId(), isHost);
+        if( myPromiseList == null){myPromiseList = new ArrayList<>();}  // null일 경우 빈 리스트 반환
 
         List<SuggestedPromiseResponseDTO> suggestedPromises = new ArrayList<>();
         List<VotingPromiseResponseDTO> votingPromises = new ArrayList<>();
@@ -115,6 +116,8 @@ public class PromiseService {
                 case PENDING -> suggestedPromises.add(mapToSuggestedPromiseDTO(promise));
                 case VOTING -> votingPromises.add(mapToVotingPromiseDTO(promise));
                 case CONFIRMED -> confirmedPromises.add(mapToConfirmedPromiseDTO(promise));
+                case ACTIVE -> {}
+                default -> throw new IllegalArgumentException();
             }
         }
 

--- a/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
@@ -31,6 +31,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static konkuk.kuit.baro.domain.promise.dto.response.SuggestionProgress.*;
@@ -104,8 +105,8 @@ public class PromiseService {
     @Transactional
     public PromiseManagementResponseDTO getPromiseManagementData(Long loginUserId, boolean isHost) {
         User loginUser = findLoginUser(loginUserId);
-        List<Promise> myPromiseList = promiseRepository.findByUserIdAndHost(loginUser.getId(), isHost);
-        if( myPromiseList == null){myPromiseList = new ArrayList<>();}  // null일 경우 빈 리스트 반환
+        List<Promise> myPromiseList = promiseRepository.findByUserIdAndHost(loginUser.getId(), isHost)
+                .orElse(new ArrayList<>());
 
         List<SuggestedPromiseResponseDTO> suggestedPromises = new ArrayList<>();
         List<VotingPromiseResponseDTO> votingPromises = new ArrayList<>();
@@ -261,7 +262,7 @@ public class PromiseService {
     }
 
     private List<String> getPromiseMembersName(Long promiseId) {
-        List<String> memberNames = promiseMemberRepository.findMemberNamesByPromiseId(promiseId);
-        return memberNames != null ? memberNames : new ArrayList<>();  // null일 경우 빈 리스트 반환
+        return promiseMemberRepository.findMemberNamesByPromiseId(promiseId)
+                .orElseGet(Collections::emptyList);
     }
 }

--- a/src/main/java/konkuk/kuit/baro/global/common/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/kuit/baro/global/common/config/swagger/SwaggerResponseDescription.java
@@ -56,6 +56,12 @@ public enum SwaggerResponseDescription {
             USER_NOT_FOUND,
             PROMISE_NOT_FOUND
     ))),
+    PROMISE_MANAGING_PAGE(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND
+    ))),
+    HOST_PROMISE_MANAGING_PAGE(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND
+    ))),
 
     //Schedule
     SCHEDULE_ADD(new LinkedHashSet<>(Set.of(

--- a/src/main/java/konkuk/kuit/baro/global/common/util/DateUtil.java
+++ b/src/main/java/konkuk/kuit/baro/global/common/util/DateUtil.java
@@ -1,0 +1,15 @@
+package konkuk.kuit.baro.global.common.util;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+
+public class DateUtil {
+
+    private DateUtil() {}
+
+    public static int calculateDday(LocalDate endDate) {
+        return (int) ChronoUnit.DAYS.between(LocalDate.now(), endDate);
+    }
+}
+


### PR DESCRIPTION
## Related issue 🛠
- open #28  

## Work Description 📝
### PromiseService
#### getPromiseManagementData
- 기본적으로 이 메서드를 사용해서 약속들을 반환합니다. 
- 호스트일 때랑 아닐때를 판별하여 반환하도록 하였습니다.
- DTO를 3가지를 만들어 하나로 합쳐서 보내는 식으로 로직을 짰습니다. 이게 프론트 입장에서 구분하기 쉽다고 해서 구현했는데 혹시 다른 좋은 방법있으면 피드백 부탁드립니다. 

### PromiseController
- 그래서 호스트일 때랑 아닐때를 2개의 api url을 추가했습니다. 

### PromiseMemberRepository
- promsieMember들의 이름을 반환하는 메서드를 구현했습니다. 

### PromiseRepository
- promiseMember들의 Id와 host인지를 통해 promise를 list로 반환하는 메서드를 구현했습니다. 

## Screenshot 📸
<img src="" width="360"/>

## Uncompleted Tasks 😅
- [ ] Task1

## To Reviewers 📢

약속 생성시에는 status를 ACTIVE로 관리하다가, 누군가가 pomise에서 시간 혹은 장소를 제안하면 그 때 부터 status가 PENDING으로 바뀌는게 맞는 지 여쭈어 보고 싶습니다. 

그리고, 또한 예외처리에서 handle_IllegalArgumentException 이걸로 status를 예외처리하는 걸로 일단 구현하긴 했는데, 이거는 인자의 오류를 예외처리 하는거라서 좀 더 세세하게 예외처리를 하려면 handle_IllegalStateException(HttpStatus.BAD_REQUEST)을 구현하여 Status에 대한 예외처리를 하고 싶은데 여러분들의 의견이 궁금합니다!


