### PR TITLE
[Feat] 약속 현황 - 확정

### DIFF
--- a/src/main/java/konkuk/kuit/baro/domain/promise/controller/PromiseController.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/controller/PromiseController.java
@@ -94,4 +94,12 @@ public class PromiseController {
                                                                                 @RequestParam("isHost") Boolean isHost) {
         return BaseResponse.ok(promiseService.getVotingPromise(promiseId, isHost));
     }
+
+    @Tag(name = "약속 현황 API", description = "약속 현황 관련 API")
+    @Operation(summary = "약속 현황 - 확정", description = "약속 상태가 '확정'인 약속의 현황을 조회합니다.")
+    @GetMapping("/{promiseId}/confirmed")
+    @CustomExceptionDescription(CONFIRMED_PROMISE_STATUS)
+    public BaseResponse<PromiseStatusConfirmedPromiseResponseDTO> getConfirmedPromiseResponse(@PathVariable("promiseId") Long promiseId) {
+        return BaseResponse.ok(promiseService.getConfirmedPromise(promiseId));
+    }
 }

--- a/src/main/java/konkuk/kuit/baro/domain/promise/controller/PromiseController.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/controller/PromiseController.java
@@ -2,42 +2,22 @@ package konkuk.kuit.baro.domain.promise.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.annotation.PostConstruct;
-import jakarta.persistence.EntityManager;
 import jakarta.validation.Valid;
-import konkuk.kuit.baro.domain.place.model.Place;
-import konkuk.kuit.baro.domain.place.repository.PlaceRepository;
 import konkuk.kuit.baro.domain.promise.dto.request.PromiseSuggestRequestDTO;
 import konkuk.kuit.baro.domain.promise.dto.request.SetPromiseAvailableTimeRequestDTO;
 import konkuk.kuit.baro.domain.promise.dto.response.*;
-import konkuk.kuit.baro.domain.promise.model.*;
-import konkuk.kuit.baro.domain.promise.repository.*;
+import konkuk.kuit.baro.domain.promise.dto.response.PendingPromiseResponseDTO;
+import konkuk.kuit.baro.domain.promise.dto.response.PromiseAvailableTimeResponseDTO;
+import konkuk.kuit.baro.domain.promise.dto.response.PromiseStatusResponseDTO;
 import konkuk.kuit.baro.domain.promise.service.PromiseAvailableTimeService;
 import konkuk.kuit.baro.domain.promise.service.PromiseService;
-import konkuk.kuit.baro.domain.user.model.User;
-import konkuk.kuit.baro.domain.user.repository.UserRepository;
-import konkuk.kuit.baro.domain.vote.model.PromisePlaceVoteHistory;
-import konkuk.kuit.baro.domain.vote.model.PromiseTimeVoteHistory;
-import konkuk.kuit.baro.domain.vote.model.PromiseVote;
-import konkuk.kuit.baro.domain.vote.repository.PromisePlaceVoteHistoryRepository;
-import konkuk.kuit.baro.domain.vote.repository.PromiseTimeVoteHistoryRepository;
-import konkuk.kuit.baro.domain.vote.repository.PromiseVoteRepository;
 import konkuk.kuit.baro.global.auth.resolver.CurrentUserId;
 import konkuk.kuit.baro.global.common.annotation.CustomExceptionDescription;
 import konkuk.kuit.baro.global.common.response.BaseResponse;
-import konkuk.kuit.baro.global.common.response.status.BaseStatus;
-import konkuk.kuit.baro.global.common.util.GeometryUtil;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.locationtech.jts.geom.Coordinate;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.bind.annotation.*;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
 
 import static konkuk.kuit.baro.global.common.config.swagger.SwaggerResponseDescription.*;
 
@@ -82,9 +62,9 @@ public class PromiseController {
     @Operation(summary = "약속 상태 확인", description = "약속의 상태를 확인합니다.")
     @GetMapping("/{promiseId}/status")
     @CustomExceptionDescription(PROMISE_STATUS)
-    public BaseResponse<PromiseStatusResponseDTO> getPromiseStatus(//@CurrentUserId Long userId,
+    public BaseResponse<PromiseStatusResponseDTO> getPromiseStatus(@CurrentUserId Long userId,
                                                                    @PathVariable("promiseId") Long promiseId) {
-        return BaseResponse.ok(promiseService.getPromiseStatus(1L, promiseId));
+        return BaseResponse.ok(promiseService.getPromiseStatus(userId, promiseId));
     }
 
     @Tag(name = "약속 현황 API", description = "약속 현황 관련 API")

--- a/src/main/java/konkuk/kuit/baro/domain/promise/dto/response/PromiseStatusConfirmedPromiseResponseDTO.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/dto/response/PromiseStatusConfirmedPromiseResponseDTO.java
@@ -1,0 +1,26 @@
+package konkuk.kuit.baro.domain.promise.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class PromiseStatusConfirmedPromiseResponseDTO {
+
+    @Schema(description = "약속 이름", example = "KUIT BARO 2차 회의")
+    private String promiseName;
+
+    @Schema(description = "약속 확정 장소 이름", example = "건대입구역")
+    private String confirmedPlace;
+
+    @Schema(description = "약속 확정 날짜", example = "3/14(금) 3시")
+    private String confirmedDate;
+
+    @Schema(description = "위도", example = "37.566545")
+    private Double latitude;
+
+    @Schema(description = "경도", example = "126.978078")
+    private Double longitude;
+}

--- a/src/main/java/konkuk/kuit/baro/domain/promise/dto/response/VotingPromiseResponseDTO.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/dto/response/VotingPromiseResponseDTO.java
@@ -2,7 +2,6 @@ package konkuk.kuit.baro.domain.promise.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
-
 import java.time.LocalDate;
 
 @Getter

--- a/src/main/java/konkuk/kuit/baro/domain/promise/model/Promise.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/model/Promise.java
@@ -41,12 +41,8 @@ public class Promise extends BaseEntity {
     private LocalDate fixedDate;
 
     @Setter
-    @Column(name = "fixed_start_time")
-    private LocalTime fixedStartTime;
-
-    @Setter
-    @Column(name = "fixed_end_time")
-    private LocalTime fixedEndTime;
+    @Column(name = "fixed_time")
+    private LocalTime fixedTime;
 
     @Setter
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/konkuk/kuit/baro/domain/promise/model/Promise.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/model/Promise.java
@@ -10,8 +10,11 @@ import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.TextStyle;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 @Entity
 @Table(name = "promise")
@@ -65,6 +68,19 @@ public class Promise extends BaseEntity {
         this.suggestedStartDate = suggestedStartDate;
         this.suggestedEndDate = suggestedEndDate;
         this.setStatus(BaseStatus.PENDING);
+    }
+
+    public String extractFixedDateAndTime() {
+        // 날짜 형식 변환
+        String datePart = fixedDate.format(DateTimeFormatter.ofPattern("M/d"));
+
+        // 요일 변환 (한글 요일)
+        String dayOfWeek = fixedDate.getDayOfWeek().getDisplayName(TextStyle.SHORT, Locale.KOREAN);
+
+        // 시간 변환 (h시)
+        String timePart = fixedTime.format(DateTimeFormatter.ofPattern("h시"));
+
+        return datePart + "(" + dayOfWeek + ") " + timePart;
     }
 
     // 연관 관계 편의 메서드

--- a/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
@@ -1,5 +1,6 @@
 package konkuk.kuit.baro.domain.promise.service;
 
+import konkuk.kuit.baro.domain.place.model.Place;
 import konkuk.kuit.baro.domain.promise.dto.request.PromiseSuggestRequestDTO;
 import konkuk.kuit.baro.domain.promise.dto.response.PendingPromiseResponseDTO;
 import konkuk.kuit.baro.domain.promise.dto.response.PromiseMemberSuggestStateDTO;
@@ -29,6 +30,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 
 import static konkuk.kuit.baro.domain.promise.dto.response.SuggestionProgress.*;
@@ -169,6 +172,26 @@ public class PromiseService {
         }
 
         return new PromiseStatusVotingPromiseResponseDTO(promiseName, null, promiseMemberVoteState);
+    }
+
+    // 약속 현황 조회 - 확정
+    public PromiseStatusConfirmedPromiseResponseDTO getConfirmedPromise(Long promiseId) {
+        Promise findPromise = findPromise(promiseId);
+
+        Place fixedPlace = findPromise.getPlace();
+        LocalDate fixedDate = findPromise.getFixedDate();
+        LocalTime fixedTime = findPromise.getFixedTime();
+
+        if (fixedPlace == null || fixedDate == null || fixedTime == null) {
+            throw new CustomException(ErrorCode.PROMISE_NOT_CONFIRMED);
+        }
+
+        return new PromiseStatusConfirmedPromiseResponseDTO(
+                findPromise.getPromiseName(),
+                fixedPlace.getPlaceName(),
+                findPromise.extractFixedDateAndTime(),
+                fixedPlace.getLocation().getY(),
+                fixedPlace.getLocation().getX());
     }
 
 

--- a/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
@@ -171,6 +171,7 @@ public class PromiseService {
         return new PromiseStatusVotingPromiseResponseDTO(promiseName, null, promiseMemberVoteState);
     }
 
+
     private User findLoginUser(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));

--- a/src/main/java/konkuk/kuit/baro/global/common/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/kuit/baro/global/common/config/swagger/SwaggerResponseDescription.java
@@ -103,6 +103,11 @@ public enum SwaggerResponseDescription {
     VOTING_PROMISE_STATUS(new LinkedHashSet<>(Set.of(
             PROMISE_NOT_FOUND,
             PROMISE_VOTE_NOT_STARTED
+    ))),
+
+    CONFIRMED_PROMISE_STATUS(new LinkedHashSet<>(Set.of(
+            PROMISE_NOT_FOUND,
+            PROMISE_NOT_CONFIRMED
     )));
 
     private final Set<ErrorCode> errorCodeList;

--- a/src/main/java/konkuk/kuit/baro/global/common/response/status/ErrorCode.java
+++ b/src/main/java/konkuk/kuit/baro/global/common/response/status/ErrorCode.java
@@ -35,6 +35,7 @@ public enum ErrorCode implements ResponseStatus {
     PLACE_NOT_FOUND(401, HttpStatus.NOT_FOUND.value(), "존재하지 않는 장소입니다."),
     //Promise
     PROMISE_NOT_FOUND(500, HttpStatus.NOT_FOUND.value(),"존재하지 않는 약속입니다."),
+    PROMISE_NOT_CONFIRMED(501, BAD_REQUEST.value(), "확정되지 않은 약속입니다."),
 
     //인증, 인가
     SECURITY_UNAUTHORIZED(600,HttpStatus.UNAUTHORIZED.value(), "인증 정보가 유효하지 않습니다"),

--- a/src/test/java/konkuk/kuit/baro/domain/promise/service/PromiseServiceTest.java
+++ b/src/test/java/konkuk/kuit/baro/domain/promise/service/PromiseServiceTest.java
@@ -1,4 +1,110 @@
+package konkuk.kuit.baro.domain.promise.service;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import konkuk.kuit.baro.domain.place.model.Place;
+import konkuk.kuit.baro.domain.place.repository.PlaceRepository;
+import konkuk.kuit.baro.domain.promise.dto.response.ConfirmedPromiseResponseDTO;
+import konkuk.kuit.baro.domain.promise.model.Promise;
+import konkuk.kuit.baro.domain.promise.repository.PromiseRepository;
+import konkuk.kuit.baro.global.common.exception.CustomException;
+import konkuk.kuit.baro.global.common.response.status.ErrorCode;
+import konkuk.kuit.baro.global.common.util.GeometryUtil;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
 class PromiseServiceTest {
-  
+
+    @Autowired
+    private PromiseRepository promiseRepository;
+    @Autowired
+    private PlaceRepository placeRepository;
+
+    @Autowired private PromiseService promiseService;
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Test
+    @DisplayName("약속 현황 - 확정 테스트")
+    @Rollback(value = false)
+    void confirm() {
+        // given
+        Promise promise = Promise.builder()
+                .promiseName("컴퓨터 공학부 개강파티")
+                .suggestedRegion("지그재그")
+                .suggestedStartDate(LocalDate.now().minusDays(1))
+                .suggestedEndDate(LocalDate.now().plusDays(1))
+                .build();
+
+        promiseRepository.save(promise);
+
+        Place place = Place.builder()
+                .placeName("스타벅스 건대점")
+                .location(GeometryUtil.createPoint(37.7749295, 122.4194155))
+                .placeAddress("광진구 화양동")
+                .build();
+
+        placeRepository.save(place);
+
+        em.flush();
+        em.clear();
+
+        // when
+
+        Promise findPromise = promiseRepository.findById(1L).get();
+        Place findPlace = placeRepository.findById(1L).get();
+
+        findPromise.setPlace(findPlace);
+        findPromise.setFixedDate(LocalDate.now());
+        findPromise.setFixedTime(LocalTime.now());
+
+        em.flush();
+        em.clear();
+
+        // then
+        ConfirmedPromiseResponseDTO confirmedPromise = promiseService.getConfirmedPromise(findPromise.getId());
+
+        assertThat(confirmedPromise.getPromiseName()).isEqualTo("컴퓨터 공학부 개강파티");
+        assertThat(confirmedPromise.getConfirmedPlace()).isEqualTo("스타벅스 건대점");
+        assertThat(confirmedPromise.getLatitude()).isEqualTo(37.7749295);
+        assertThat(confirmedPromise.getLongitude()).isEqualTo(122.4194155);
+    }
+
+    @Test
+    @DisplayName("약속 확정 에러 테스트")
+    void confirm_exception() {
+        // given
+        Promise promise = Promise.builder()
+                .promiseName("컴퓨터 공학부 개강파티")
+                .suggestedRegion("지그재그")
+                .suggestedStartDate(LocalDate.now().minusDays(1))
+                .suggestedEndDate(LocalDate.now().plusDays(1))
+                .build();
+
+        Promise savedPromise = promiseRepository.save(promise);
+
+        em.flush();
+        em.clear();
+
+        // then
+        assertThatThrownBy(() -> promiseService.getConfirmedPromise(savedPromise.getId()))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ErrorCode.PROMISE_NOT_CONFIRMED.getMessage());
+    }
+
 }

--- a/src/test/java/konkuk/kuit/baro/domain/promise/service/PromiseServiceTest.java
+++ b/src/test/java/konkuk/kuit/baro/domain/promise/service/PromiseServiceTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class PromiseServiceTest {
+  
+}


### PR DESCRIPTION
## Related issue 🛠
- closed #46 

## Work Description 📝
### 약속 현황 - 확정 API 구현

약속 현황 - 확정 API 를 구현하였습니다.
이 API의 경우 약속 엔티티가 갖는 fixedDate, fixedTime 의 정보를 가져와서 적절히 변환해 반환해주었습니다.

### Promise 엔티티 수정
프로젝트의 기획상 확정된 약속 시작 시간, 확정된 약속 종료 시간 과 같이 시작 시간, 종료 시간을 나누지 않고 오로지 '확정 시간' 하나만을 관리하는 로직으로 변경됨에 따라 Promise 엔티티의 내용도 수정해주었습니다.

## Screenshot 📸

## Uncompleted Tasks 😅

## To Reviewers 📢
