### PR TITLE
[Feat] 약속 제안 남은 시간 조회 & 투표 종료까지 남은 시간 조회

### DIFF
--- a/src/main/java/konkuk/kuit/baro/domain/promise/controller/PromiseController.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/controller/PromiseController.java
@@ -133,4 +133,12 @@ public class PromiseController {
     public BaseResponse<PromiseSuggestRemainingTimeResponseDTO> getPromiseSuggestRemainingTimeResponse(@PathVariable("promiseId") Long promiseId) {
         return BaseResponse.ok(promiseService.getPromiseSuggestRemainingTime(promiseId));
     }
+
+    @Tag(name = "약속 현황 API", description = "약속 현황 관련 API")
+    @Operation(summary = "투표 남은 시간 조회", description = "투표 만료까지 남은 시간을 조회합니다. 24시간 이상 남을 경우 D-N 형식, 24시간 미만으로 남을 경우 OO시 OO분 OO초 형식")
+    @GetMapping("/{promiseId}/vote-remaining-time")
+    @CustomExceptionDescription(PROMISE_VOTE_REMAINING_TIME)
+    public BaseResponse<PromiseVoteRemainingTimeResponseDTO> getPromiseVoteRemainingTimeResponse(@PathVariable("promiseId") Long promiseId) {
+        return BaseResponse.ok(promiseService.getPromiseVoteRemainingTime(promiseId));
+    }
 }

--- a/src/main/java/konkuk/kuit/baro/domain/promise/controller/PromiseController.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/controller/PromiseController.java
@@ -125,4 +125,12 @@ public class PromiseController {
     public BaseResponse<PromiseStatusConfirmedPromiseResponseDTO> getConfirmedPromiseResponse(@PathVariable("promiseId") Long promiseId) {
         return BaseResponse.ok(promiseService.getConfirmedPromise(promiseId));
     }
+
+    @Tag(name = "약속 현황 API", description = "약속 현황 관련 API")
+    @Operation(summary = "약속 제안 남은 시간 조회", description = "약속 제안의 남은 시간을 조회합니다. 24시간 이상 남을 경우 D-N 형식, 24시간 미만으로 남을 경우 OO시 OO분 OO초 형식")
+    @GetMapping("/{promiseId}/suggest-remaining-time")
+    @CustomExceptionDescription(PROMISE_SUGGEST_REMAINING_TIME)
+    public BaseResponse<PromiseSuggestRemainingTimeResponseDTO> getPromiseSuggestRemainingTimeResponse(@PathVariable("promiseId") Long promiseId) {
+        return BaseResponse.ok(promiseService.getPromiseSuggestRemainingTime(promiseId));
+    }
 }

--- a/src/main/java/konkuk/kuit/baro/domain/promise/controller/PromiseController.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/controller/PromiseController.java
@@ -14,10 +14,33 @@ import konkuk.kuit.baro.domain.promise.service.PromiseService;
 import konkuk.kuit.baro.global.auth.resolver.CurrentUserId;
 import konkuk.kuit.baro.global.common.annotation.CustomExceptionDescription;
 import konkuk.kuit.baro.global.common.response.BaseResponse;
+import konkuk.kuit.baro.domain.promise.dto.response.VotingPromiseResponseDTO;
+import konkuk.kuit.baro.domain.promise.model.*;
+import konkuk.kuit.baro.domain.promise.repository.*;
+import konkuk.kuit.baro.domain.promise.service.PromiseAvailableTimeService;
+import konkuk.kuit.baro.domain.promise.service.PromiseService;
+import konkuk.kuit.baro.domain.user.model.User;
+import konkuk.kuit.baro.domain.user.repository.UserRepository;
+import konkuk.kuit.baro.domain.vote.model.PromisePlaceVoteHistory;
+import konkuk.kuit.baro.domain.vote.model.PromiseTimeVoteHistory;
+import konkuk.kuit.baro.domain.vote.model.PromiseVote;
+import konkuk.kuit.baro.domain.vote.repository.PromisePlaceVoteHistoryRepository;
+import konkuk.kuit.baro.domain.vote.repository.PromiseTimeVoteHistoryRepository;
+import konkuk.kuit.baro.domain.vote.repository.PromiseVoteRepository;
+import konkuk.kuit.baro.global.auth.resolver.CurrentUserId;
+import konkuk.kuit.baro.global.common.annotation.CustomExceptionDescription;
+import konkuk.kuit.baro.global.common.response.BaseResponse;
+import konkuk.kuit.baro.global.common.response.status.BaseStatus;
+import konkuk.kuit.baro.global.common.util.GeometryUtil;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 import static konkuk.kuit.baro.global.common.config.swagger.SwaggerResponseDescription.*;
 
@@ -62,9 +85,9 @@ public class PromiseController {
     @Operation(summary = "약속 상태 확인", description = "약속의 상태를 확인합니다.")
     @GetMapping("/{promiseId}/status")
     @CustomExceptionDescription(PROMISE_STATUS)
-    public BaseResponse<PromiseStatusResponseDTO> getPromiseStatus(@CurrentUserId Long userId,
+    public BaseResponse<PromiseStatusResponseDTO> getPromiseStatus(//@CurrentUserId Long userId,
                                                                    @PathVariable("promiseId") Long promiseId) {
-        return BaseResponse.ok(promiseService.getPromiseStatus(userId, promiseId));
+        return BaseResponse.ok(promiseService.getPromiseStatus(1L, promiseId));
     }
 
     @Tag(name = "약속 현황 API", description = "약속 현황 관련 API")

--- a/src/main/java/konkuk/kuit/baro/domain/promise/controller/PromiseController.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/controller/PromiseController.java
@@ -14,33 +14,10 @@ import konkuk.kuit.baro.domain.promise.service.PromiseService;
 import konkuk.kuit.baro.global.auth.resolver.CurrentUserId;
 import konkuk.kuit.baro.global.common.annotation.CustomExceptionDescription;
 import konkuk.kuit.baro.global.common.response.BaseResponse;
-import konkuk.kuit.baro.domain.promise.dto.response.VotingPromiseResponseDTO;
-import konkuk.kuit.baro.domain.promise.model.*;
-import konkuk.kuit.baro.domain.promise.repository.*;
-import konkuk.kuit.baro.domain.promise.service.PromiseAvailableTimeService;
-import konkuk.kuit.baro.domain.promise.service.PromiseService;
-import konkuk.kuit.baro.domain.user.model.User;
-import konkuk.kuit.baro.domain.user.repository.UserRepository;
-import konkuk.kuit.baro.domain.vote.model.PromisePlaceVoteHistory;
-import konkuk.kuit.baro.domain.vote.model.PromiseTimeVoteHistory;
-import konkuk.kuit.baro.domain.vote.model.PromiseVote;
-import konkuk.kuit.baro.domain.vote.repository.PromisePlaceVoteHistoryRepository;
-import konkuk.kuit.baro.domain.vote.repository.PromiseTimeVoteHistoryRepository;
-import konkuk.kuit.baro.domain.vote.repository.PromiseVoteRepository;
-import konkuk.kuit.baro.global.auth.resolver.CurrentUserId;
-import konkuk.kuit.baro.global.common.annotation.CustomExceptionDescription;
-import konkuk.kuit.baro.global.common.response.BaseResponse;
-import konkuk.kuit.baro.global.common.response.status.BaseStatus;
-import konkuk.kuit.baro.global.common.util.GeometryUtil;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
 
 import static konkuk.kuit.baro.global.common.config.swagger.SwaggerResponseDescription.*;
 

--- a/src/main/java/konkuk/kuit/baro/domain/promise/dto/response/PromiseSuggestRemainingTimeResponseDTO.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/dto/response/PromiseSuggestRemainingTimeResponseDTO.java
@@ -1,0 +1,14 @@
+package konkuk.kuit.baro.domain.promise.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class PromiseSuggestRemainingTimeResponseDTO {
+
+    @Schema(description = "약속 제안 잔여 시간", example = "D-3 OR 1시간 1분 10초")
+    private String promiseSuggestRemainingTime;
+}

--- a/src/main/java/konkuk/kuit/baro/domain/promise/dto/response/PromiseVoteRemainingTimeResponseDTO.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/dto/response/PromiseVoteRemainingTimeResponseDTO.java
@@ -1,0 +1,14 @@
+package konkuk.kuit.baro.domain.promise.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class PromiseVoteRemainingTimeResponseDTO {
+
+    @Schema(description = "투표 잔여 시간", example = "D-3 OR 1시간 1분 10초")
+    private String promiseVoteRemainingTime;
+}

--- a/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
@@ -202,7 +202,7 @@ public class PromiseService {
 
         LocalDate suggestedEndDate = findPromise.getSuggestedEndDate();
 
-        return new PromiseSuggestRemainingTimeResponseDTO(getRemainingTimeUntilEndDate(suggestedEndDate.plusDays(1).atTime(LocalTime.MIDNIGHT)));
+        return new PromiseSuggestRemainingTimeResponseDTO(DateUtil.getRemainingTimeUntilEndDate(suggestedEndDate.plusDays(1).atTime(LocalTime.MIDNIGHT)));
     }
 
     // 투표 남은 시간 조회
@@ -210,7 +210,7 @@ public class PromiseService {
         Promise findPromise = findPromise(promiseId);
         PromiseVote findPromiseVote = findPromiseVote(findPromise);
 
-        return new PromiseVoteRemainingTimeResponseDTO(getRemainingTimeUntilEndDate(findPromiseVote.getVoteEndTime()));
+        return new PromiseVoteRemainingTimeResponseDTO(DateUtil.getRemainingTimeUntilEndDate(findPromiseVote.getVoteEndTime()));
     }
 
 
@@ -358,40 +358,6 @@ public class PromiseService {
                 )).toList();
     }
 
-    // 특정 만료 시점까지 남은 시간 반환
-    // DateUtil 이 생기면 거기에 추가해도 될 듯
-    private String getRemainingTimeUntilEndDate(LocalDateTime endDateTime) {
-        LocalDateTime now = LocalDateTime.now(); // 현재 시간
-
-        if (now.isAfter(endDateTime)) {
-            throw new CustomException(ErrorCode.TIME_EXCEED);
-        }
-
-        // DateUtil 생기면 calculateDday 메서드 가져다가 적용해도 될 듯
-        long days = ChronoUnit.DAYS.between(now, endDateTime);
-        if (days > 0) {
-            return "D-" + days;
-        }
-
-        long hours = ChronoUnit.HOURS.between(now, endDateTime);
-        long minutes = ChronoUnit.MINUTES.between(now, endDateTime) % 60;
-        long seconds = ChronoUnit.SECONDS.between(now, endDateTime) % 60;
-
-        StringBuilder time = new StringBuilder();
-        if (hours > 0) {
-            time.append(hours).append("시간 ");
-        }
-
-        if (minutes > 0) {
-            time.append(minutes).append("분 ");
-        }
-
-        if (seconds > 0 || time.isEmpty()) {
-            time.append(seconds).append("초");
-        }
-
-        return time.toString().trim();
-    }
 
 
 }

--- a/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
@@ -194,6 +194,26 @@ public class PromiseService {
                 fixedPlace.getLocation().getX());
     }
 
+    // 약속 현황 조회 - 확정
+    public ConfirmedPromiseResponseDTO getConfirmedPromise(Long promiseId) {
+        Promise findPromise = findPromise(promiseId);
+
+        Place fixedPlace = findPromise.getPlace();
+        LocalDate fixedDate = findPromise.getFixedDate();
+        LocalTime fixedTime = findPromise.getFixedTime();
+
+        if (fixedPlace == null || fixedDate == null || fixedTime == null) {
+            throw new CustomException(ErrorCode.PROMISE_NOT_CONFIRMED);
+        }
+
+        return new ConfirmedPromiseResponseDTO(
+                findPromise.getPromiseName(),
+                fixedPlace.getPlaceName(),
+                findPromise.extractFixedDateAndTime(),
+                fixedPlace.getLocation().getY(),
+                fixedPlace.getLocation().getX());
+    }
+
 
     private User findLoginUser(Long userId) {
         return userRepository.findById(userId)

--- a/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
@@ -196,26 +196,6 @@ public class PromiseService {
                 fixedPlace.getLocation().getX());
     }
 
-    // 약속 현황 조회 - 확정
-    public ConfirmedPromiseResponseDTO getConfirmedPromise(Long promiseId) {
-        Promise findPromise = findPromise(promiseId);
-
-        Place fixedPlace = findPromise.getPlace();
-        LocalDate fixedDate = findPromise.getFixedDate();
-        LocalTime fixedTime = findPromise.getFixedTime();
-
-        if (fixedPlace == null || fixedDate == null || fixedTime == null) {
-            throw new CustomException(ErrorCode.PROMISE_NOT_CONFIRMED);
-        }
-
-        return new ConfirmedPromiseResponseDTO(
-                findPromise.getPromiseName(),
-                fixedPlace.getPlaceName(),
-                findPromise.extractFixedDateAndTime(),
-                fixedPlace.getLocation().getY(),
-                fixedPlace.getLocation().getX());
-    }
-
     // 약속 제안 남은 시간 조회
     public PromiseSuggestRemainingTimeResponseDTO getPromiseSuggestRemainingTime(Long promiseId) {
         Promise findPromise = findPromise(promiseId);

--- a/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
@@ -222,7 +222,15 @@ public class PromiseService {
 
         LocalDate suggestedEndDate = findPromise.getSuggestedEndDate();
 
-        return new PromiseSuggestRemainingTimeResponseDTO(getRemainingTimeUntilEndDate(suggestedEndDate));
+        return new PromiseSuggestRemainingTimeResponseDTO(getRemainingTimeUntilEndDate(suggestedEndDate.plusDays(1).atTime(LocalTime.MIDNIGHT)));
+    }
+
+    // 투표 남은 시간 조회
+    public PromiseVoteRemainingTimeResponseDTO getPromiseVoteRemainingTime(Long promiseId) {
+        Promise findPromise = findPromise(promiseId);
+        PromiseVote findPromiseVote = findPromiseVote(findPromise);
+
+        return new PromiseVoteRemainingTimeResponseDTO(getRemainingTimeUntilEndDate(findPromiseVote.getVoteEndTime()));
     }
 
 
@@ -370,14 +378,13 @@ public class PromiseService {
                 )).toList();
     }
 
-    // 제안 종료일까지 남은 시간 반환
+    // 특정 만료 시점까지 남은 시간 반환
     // DateUtil 이 생기면 거기에 추가해도 될 듯
-    private String getRemainingTimeUntilEndDate(LocalDate suggestedEndDate) {
+    private String getRemainingTimeUntilEndDate(LocalDateTime endDateTime) {
         LocalDateTime now = LocalDateTime.now(); // 현재 시간
-        LocalDateTime endDateTime = suggestedEndDate.plusDays(1).atTime(LocalTime.MIDNIGHT);
 
         if (now.isAfter(endDateTime)) {
-            throw new CustomException(ErrorCode.PROMISE_SUGGEST_EXPIRED);
+            throw new CustomException(ErrorCode.TIME_EXCEED);
         }
 
         // DateUtil 생기면 calculateDday 메서드 가져다가 적용해도 될 듯
@@ -405,5 +412,6 @@ public class PromiseService {
 
         return time.toString().trim();
     }
+
 
 }

--- a/src/main/java/konkuk/kuit/baro/global/common/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/kuit/baro/global/common/config/swagger/SwaggerResponseDescription.java
@@ -112,7 +112,13 @@ public enum SwaggerResponseDescription {
 
     PROMISE_SUGGEST_REMAINING_TIME(new LinkedHashSet<>(Set.of(
             PROMISE_NOT_FOUND,
-            PROMISE_SUGGEST_EXPIRED
+            TIME_EXCEED
+    ))),
+
+    PROMISE_VOTE_REMAINING_TIME(new LinkedHashSet<>(Set.of(
+            PROMISE_NOT_FOUND,
+            PROMISE_VOTE_NOT_STARTED,
+            TIME_EXCEED
     )));
 
     private final Set<ErrorCode> errorCodeList;

--- a/src/main/java/konkuk/kuit/baro/global/common/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/kuit/baro/global/common/config/swagger/SwaggerResponseDescription.java
@@ -108,6 +108,11 @@ public enum SwaggerResponseDescription {
     CONFIRMED_PROMISE_STATUS(new LinkedHashSet<>(Set.of(
             PROMISE_NOT_FOUND,
             PROMISE_NOT_CONFIRMED
+    ))),
+
+    PROMISE_SUGGEST_REMAINING_TIME(new LinkedHashSet<>(Set.of(
+            PROMISE_NOT_FOUND,
+            PROMISE_SUGGEST_EXPIRED
     )));
 
     private final Set<ErrorCode> errorCodeList;

--- a/src/main/java/konkuk/kuit/baro/global/common/response/status/ErrorCode.java
+++ b/src/main/java/konkuk/kuit/baro/global/common/response/status/ErrorCode.java
@@ -36,7 +36,6 @@ public enum ErrorCode implements ResponseStatus {
     //Promise
     PROMISE_NOT_FOUND(500, HttpStatus.NOT_FOUND.value(),"존재하지 않는 약속입니다."),
     PROMISE_NOT_CONFIRMED(501, BAD_REQUEST.value(), "확정되지 않은 약속입니다."),
-    PROMISE_SUGGEST_EXPIRED(502, BAD_REQUEST.value(), "약속 제안이 만료되었습니다."),
 
     //인증, 인가
     SECURITY_UNAUTHORIZED(600,HttpStatus.UNAUTHORIZED.value(), "인증 정보가 유효하지 않습니다"),
@@ -56,7 +55,11 @@ public enum ErrorCode implements ResponseStatus {
     PROMISE_MEMBER_NOT_FOUND(700, HttpStatus.NOT_FOUND.value(), "해당 약속에 참여한 사용자가 아닙니다."),
 
     // PromiseVote
-    PROMISE_VOTE_NOT_STARTED(800, BAD_REQUEST.value(), "아직 투표가 개설되지 않았습니다.");
+    PROMISE_VOTE_NOT_STARTED(800, BAD_REQUEST.value(), "아직 투표가 개설되지 않았습니다."),
+
+    // Time
+    TIME_EXCEED(900, BAD_REQUEST.value(), "만료시간이 지났습니다");
+
 
     @Getter
     private final int code;

--- a/src/main/java/konkuk/kuit/baro/global/common/response/status/ErrorCode.java
+++ b/src/main/java/konkuk/kuit/baro/global/common/response/status/ErrorCode.java
@@ -36,6 +36,7 @@ public enum ErrorCode implements ResponseStatus {
     //Promise
     PROMISE_NOT_FOUND(500, HttpStatus.NOT_FOUND.value(),"존재하지 않는 약속입니다."),
     PROMISE_NOT_CONFIRMED(501, BAD_REQUEST.value(), "확정되지 않은 약속입니다."),
+    PROMISE_SUGGEST_EXPIRED(502, BAD_REQUEST.value(), "약속 제안이 만료되었습니다."),
 
     //인증, 인가
     SECURITY_UNAUTHORIZED(600,HttpStatus.UNAUTHORIZED.value(), "인증 정보가 유효하지 않습니다"),

--- a/src/main/java/konkuk/kuit/baro/global/common/util/DateUtil.java
+++ b/src/main/java/konkuk/kuit/baro/global/common/util/DateUtil.java
@@ -1,6 +1,10 @@
 package konkuk.kuit.baro.global.common.util;
 
+import konkuk.kuit.baro.global.common.exception.CustomException;
+import konkuk.kuit.baro.global.common.response.status.ErrorCode;
+
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 
 
@@ -10,6 +14,38 @@ public class DateUtil {
 
     public static int calculateDday(LocalDate endDate) {
         return (int) ChronoUnit.DAYS.between(LocalDate.now(), endDate);
+    }
+
+    public static String getRemainingTimeUntilEndDate(LocalDateTime endDateTime) {
+        LocalDateTime now = LocalDateTime.now(); // 현재 시간
+
+        if (now.isAfter(endDateTime)) {
+            throw new CustomException(ErrorCode.TIME_EXCEED);
+        }
+
+        long days = ChronoUnit.DAYS.between(now, endDateTime);
+        if (days > 0) {
+            return "D-" + days;
+        }
+
+        long hours = ChronoUnit.HOURS.between(now, endDateTime);
+        long minutes = ChronoUnit.MINUTES.between(now, endDateTime) % 60;
+        long seconds = ChronoUnit.SECONDS.between(now, endDateTime) % 60;
+
+        StringBuilder time = new StringBuilder();
+        if (hours > 0) {
+            time.append(hours).append("시간 ");
+        }
+
+        if (minutes > 0) {
+            time.append(minutes).append("분 ");
+        }
+
+        if (seconds > 0 || time.isEmpty()) {
+            time.append(seconds).append("초");
+        }
+
+        return time.toString().trim();
     }
 }
 

--- a/src/test/java/konkuk/kuit/baro/domain/promise/service/PromiseServiceTest.java
+++ b/src/test/java/konkuk/kuit/baro/domain/promise/service/PromiseServiceTest.java
@@ -107,4 +107,47 @@ class PromiseServiceTest {
                 .hasMessage(ErrorCode.PROMISE_NOT_CONFIRMED.getMessage());
     }
 
+    @Test
+    @DisplayName("약속 제안 남은 시간 조회 테스트")
+    void promiseSuggestRemainingTime() {
+        // given
+        Promise promise = Promise.builder()
+                .promiseName("컴퓨터 공학부 개강파티")
+                .suggestedRegion("지그재그")
+                .suggestedStartDate(LocalDate.now().minusDays(1))
+                .suggestedEndDate(LocalDate.now().plusDays(1))
+                .build();
+
+        Promise savedPromise = promiseRepository.save(promise);
+
+        em.flush();
+        em.clear();
+
+        // when & then
+        assertThat(promiseService.getPromiseSuggestRemainingTime(savedPromise.getId()).getPromiseSuggestRemainingTime()).isEqualTo("D-1");
+    }
+
+    @Test
+    @DisplayName("약속 제안 남은 시간 조회 예외 테스트")
+    void promiseSuggestRemainingTimeException() {
+        // given
+        Promise promise = Promise.builder()
+                .promiseName("컴퓨터 공학부 개강파티")
+                .suggestedRegion("지그재그")
+                .suggestedStartDate(LocalDate.now().minusDays(1))
+                .suggestedEndDate(LocalDate.now().minusDays(2))
+                .build();
+
+        Promise savedPromise = promiseRepository.save(promise);
+
+        em.flush();
+        em.clear();
+
+        // when & then
+        assertThatThrownBy(() -> promiseService.getPromiseSuggestRemainingTime(savedPromise.getId()))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ErrorCode.PROMISE_SUGGEST_EXPIRED.getMessage());
+
+    }
+
 }

--- a/src/test/java/konkuk/kuit/baro/domain/promise/service/PromiseServiceTest.java
+++ b/src/test/java/konkuk/kuit/baro/domain/promise/service/PromiseServiceTest.java
@@ -5,6 +5,7 @@ import jakarta.persistence.PersistenceContext;
 import konkuk.kuit.baro.domain.place.model.Place;
 import konkuk.kuit.baro.domain.place.repository.PlaceRepository;
 import konkuk.kuit.baro.domain.promise.dto.response.ConfirmedPromiseResponseDTO;
+import konkuk.kuit.baro.domain.promise.dto.response.PromiseStatusConfirmedPromiseResponseDTO;
 import konkuk.kuit.baro.domain.promise.model.Promise;
 import konkuk.kuit.baro.domain.promise.repository.PromiseRepository;
 import konkuk.kuit.baro.domain.vote.model.PromiseVote;
@@ -81,7 +82,7 @@ class PromiseServiceTest {
         em.clear();
 
         // then
-        ConfirmedPromiseResponseDTO confirmedPromise = promiseService.getConfirmedPromise(findPromise.getId());
+        PromiseStatusConfirmedPromiseResponseDTO confirmedPromise = promiseService.getConfirmedPromise(findPromise.getId());
 
         assertThat(confirmedPromise.getPromiseName()).isEqualTo("컴퓨터 공학부 개강파티");
         assertThat(confirmedPromise.getConfirmedPlace()).isEqualTo("스타벅스 건대점");
@@ -217,7 +218,7 @@ class PromiseServiceTest {
         em.flush();
         em.clear();
 
-        assertThatThrownBy(() -> promiseService.getPromiseVoteRemainingTime(1L).getPromiseVoteRemainingTime())
+        assertThatThrownBy(() -> promiseService.getPromiseVoteRemainingTime(1L))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(ErrorCode.TIME_EXCEED.getMessage());
     }


### PR DESCRIPTION
## Related issue 🛠
- closed #48 

## Work Description 📝
### 약속 남은 시간 조회 & 투표 종료까지 남은 시간 조회 API 구현

약속 남은 시간 조회와 투표 종료까지 남은 시간 조회 API 를 구현하였습니다.
두 로직이 사실상 동일하다고도 볼 수 있어서 공통된 메서드로 동작을 처리하도록 하였습니다.

만약 종료시점까지 24시간 이상 남았다면 D-N 일 형태로 값을 반환하며, 24시간 미만으로 남았다면 OO시 OO분 OO초 단위로 반환하도록 합니다.

이 때 사용한 메서드들도 Date와 연관성이 깊기에 추후 DateUtil 클래스가 추가된다면, 해당 클래스로 메서드를 옮겨서 사용해도 좋을 것 같습니다.

## Screenshot 📸

## Uncompleted Tasks 😅

## To Reviewers 📢
