### PR TITLE
[Feat] 투표 목록 조회 & 투표 참여 여부 확인

### DIFF
--- a/src/main/java/konkuk/kuit/baro/domain/place/model/Place.java
+++ b/src/main/java/konkuk/kuit/baro/domain/place/model/Place.java
@@ -3,6 +3,7 @@ package konkuk.kuit.baro.domain.place.model;
 import jakarta.persistence.*;
 import konkuk.kuit.baro.domain.category.model.PlaceCategory;
 import konkuk.kuit.baro.domain.pin.model.Pin;
+import konkuk.kuit.baro.domain.promise.model.PromiseCandidatePlace;
 import konkuk.kuit.baro.domain.promise.model.PromiseSuggestedPlace;
 import konkuk.kuit.baro.global.common.model.BaseEntity;
 import lombok.*;
@@ -46,6 +47,10 @@ public class Place extends BaseEntity {
     @OneToMany(mappedBy = "place", orphanRemoval = true)
     private List<PromiseSuggestedPlace> promiseSuggestedPlaces = new ArrayList<>();
 
+    // 장소 삭제시 약속 후보 장소도 '삭제'하기 위한 양방향 연관 관계
+    @OneToMany(mappedBy = "place", orphanRemoval = true)
+    private List<PromiseCandidatePlace> promiseCandidatePlaces = new ArrayList<>();
+
     @Builder
     public Place(String placeName, Point location, String placeAddress) {
         this.placeName = placeName;
@@ -60,5 +65,9 @@ public class Place extends BaseEntity {
 
     public void addPromiseSuggestedPlace(PromiseSuggestedPlace promiseSuggestedPlace) {
         this.promiseSuggestedPlaces.add(promiseSuggestedPlace);
+    }
+
+    public void addPromiseCandidatePlace(PromiseCandidatePlace promiseCandidatePlace) {
+        this.promiseCandidatePlaces.add(promiseCandidatePlace);
     }
 }

--- a/src/main/java/konkuk/kuit/baro/domain/promise/controller/PromiseController.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/controller/PromiseController.java
@@ -122,6 +122,7 @@ public class PromiseController {
     @Tag(name = "약속 현황 API", description = "약속 현황 관련 API")
     @Operation(summary = "투표 참여 여부 조회", description = "현재 로그인한 유저가 특정 약속에 대해 투표에 참여했는지 여부를 조회합니다.")
     @GetMapping("/{promiseId}/voting-status")
+    @CustomExceptionDescription(PROMISE_MEMBER_HAS_VOTED)
     public BaseResponse<HasVotedResponseDTO> getHasVoted(@CurrentUserId Long userId,
                                                          @PathVariable("promiseId") Long promiseId) {
         return BaseResponse.ok(promiseService.getHasVoted(userId, promiseId));

--- a/src/main/java/konkuk/kuit/baro/domain/promise/controller/PromiseController.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/controller/PromiseController.java
@@ -118,4 +118,12 @@ public class PromiseController {
     public BaseResponse<PromiseVoteRemainingTimeResponseDTO> getPromiseVoteRemainingTimeResponse(@PathVariable("promiseId") Long promiseId) {
         return BaseResponse.ok(promiseService.getPromiseVoteRemainingTime(promiseId));
     }
+
+    @Tag(name = "약속 현황 API", description = "약속 현황 관련 API")
+    @Operation(summary = "투표 참여 여부 조회", description = "현재 로그인한 유저가 특정 약속에 대해 투표에 참여했는지 여부를 조회합니다.")
+    @GetMapping("/{promiseId}/voting-status")
+    public BaseResponse<HasVotedResponseDTO> getHasVoted(@CurrentUserId Long userId,
+                                                         @PathVariable("promiseId") Long promiseId) {
+        return BaseResponse.ok(promiseService.getHasVoted(userId, promiseId));
+    }
 }

--- a/src/main/java/konkuk/kuit/baro/domain/promise/controller/PromiseController.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/controller/PromiseController.java
@@ -14,6 +14,7 @@ import konkuk.kuit.baro.domain.promise.service.PromiseService;
 import konkuk.kuit.baro.global.auth.resolver.CurrentUserId;
 import konkuk.kuit.baro.global.common.annotation.CustomExceptionDescription;
 import konkuk.kuit.baro.global.common.response.BaseResponse;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.annotation.Validated;
@@ -126,5 +127,16 @@ public class PromiseController {
     public BaseResponse<HasVotedResponseDTO> getHasVoted(@CurrentUserId Long userId,
                                                          @PathVariable("promiseId") Long promiseId) {
         return BaseResponse.ok(promiseService.getHasVoted(userId, promiseId));
+    }
+
+
+    @Tag(name = "약속 현황 API", description = "약속 현황 관련 API")
+    @Operation(summary = "투표 후보 목록 조회", description = "투표의 후보 목록을 조회합니다. 만약 투표를 하기 이전이라면 그냥 목록만 보이고, 투표를 한 이후 투표 확인, 혹은 수정을 하기 위해 진입한 경우 기존에 어떤 후보에 투표했었는지에 관한 정보를 함께 반환합니다.")
+    @GetMapping("/{promiseId}/vote-candidate-list")
+    @CustomExceptionDescription(VOTE_CANDIDATE_LIST)
+    public BaseResponse<VoteCandidateListResponseDTO> getVoteCandidateList(@CurrentUserId Long userId,
+                                                                           @PathVariable("promiseId") Long promiseId,
+                                                                           @RequestParam("hasVoted") boolean hasVoted) {
+        return BaseResponse.ok(promiseService.getVoteCandidateList(userId, promiseId, hasVoted));
     }
 }

--- a/src/main/java/konkuk/kuit/baro/domain/promise/dto/response/CandidatePlacesDTO.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/dto/response/CandidatePlacesDTO.java
@@ -1,0 +1,23 @@
+package konkuk.kuit.baro.domain.promise.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CandidatePlacesDTO {
+
+    @Schema(description = "약속 후보 장소 ID", example = "1")
+    private Long promiseCandidatePlaceId;
+
+    @Schema(description = "약속 후보 장소 이름", example = "탐앤탐스 건대입구점")
+    private String placeName;
+
+    @Schema(description = "기존에 해당 약속 후보 장소에 대해 투표했는지 여부", example = "true")
+    private Boolean isSelected;
+}

--- a/src/main/java/konkuk/kuit/baro/domain/promise/dto/response/CandidateTimesDTO.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/dto/response/CandidateTimesDTO.java
@@ -1,0 +1,26 @@
+package konkuk.kuit.baro.domain.promise.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CandidateTimesDTO {
+
+    @Schema(description = "약속 후보 시간 ID", example = "1")
+    private Long promiseCandidateTimeId;
+
+    @Schema(description = "약속 후보 시간 - 날짜 정보", example = "2025년 1월 2일")
+    private String date;
+
+    @Schema(description = "약속 후보 시간 - 시간 정보", example = "14:00")
+    private String time;
+
+    @Schema(description = "기존에 해당 약속 후보 시간에 대해 투표했는지 여부", example = "true")
+    private Boolean isSelected;
+}

--- a/src/main/java/konkuk/kuit/baro/domain/promise/dto/response/HasVotedResponseDTO.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/dto/response/HasVotedResponseDTO.java
@@ -1,0 +1,17 @@
+package konkuk.kuit.baro.domain.promise.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class HasVotedResponseDTO {
+
+    @Schema(description = "투표를 완료했는지 여부", example = "true")
+    private Boolean hasVoted;
+}

--- a/src/main/java/konkuk/kuit/baro/domain/promise/dto/response/VoteCandidateListResponseDTO.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/dto/response/VoteCandidateListResponseDTO.java
@@ -1,0 +1,22 @@
+package konkuk.kuit.baro.domain.promise.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class VoteCandidateListResponseDTO {
+
+    @Schema(description = "투표 목록 - 약속 후보 시간 리스트")
+    private List<CandidateTimesDTO> candidateTimes;
+
+    @Schema(description = "투표 모록 - 약속 후보 장소 리스트")
+    private List<CandidatePlacesDTO> candidatePlaces;
+}

--- a/src/main/java/konkuk/kuit/baro/domain/promise/model/PromiseCandidatePlace.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/model/PromiseCandidatePlace.java
@@ -1,0 +1,60 @@
+package konkuk.kuit.baro.domain.promise.model;
+
+import jakarta.persistence.*;
+import konkuk.kuit.baro.domain.place.model.Place;
+import konkuk.kuit.baro.domain.vote.model.PromisePlaceVoteHistory;
+import konkuk.kuit.baro.domain.vote.model.PromiseVote;
+import konkuk.kuit.baro.global.common.model.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "promise_candidate_place")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("status IN ('ACTIVE', 'PENDING', 'VOTING', 'CONFIRMED')")
+public class PromiseCandidatePlace extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "promise_candidate_place_id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "promis_vote_id", nullable = false)
+    private PromiseVote promiseVote;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "place_id", nullable = false)
+    private Place place;
+
+    @OneToMany(mappedBy = "promiseCandidatePlace", orphanRemoval = true)
+    private List<PromisePlaceVoteHistory> promisePlaceVoteHistories = new ArrayList<>();
+
+    // 생성 메서드
+    public static PromiseCandidatePlace createPromiseCandidatePlace(PromiseVote promiseVote, Place place) {
+        PromiseCandidatePlace promiseCandidatePlace = new PromiseCandidatePlace();
+        promiseCandidatePlace.setPromiseVote(promiseVote);
+        promiseCandidatePlace.setPlace(place);
+        return promiseCandidatePlace;
+    }
+
+    // 연관 관계 편의 메서드
+    private void setPromiseVote(PromiseVote promiseVote) {
+        this.promiseVote = promiseVote;
+        promiseVote.addPromiseCandidatePlace(this);
+    }
+
+    private void setPlace(Place place) {
+        this.place = place;
+        place.addPromiseCandidatePlace(this);
+    }
+
+    public void addPromisePlaceVoteHistory(PromisePlaceVoteHistory promisePlaceVoteHistory) {
+        this.promisePlaceVoteHistories.add(promisePlaceVoteHistory);
+    }
+}

--- a/src/main/java/konkuk/kuit/baro/domain/promise/model/PromiseSuggestedPlace.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/model/PromiseSuggestedPlace.java
@@ -2,7 +2,6 @@ package konkuk.kuit.baro.domain.promise.model;
 
 import jakarta.persistence.*;
 import konkuk.kuit.baro.domain.place.model.Place;
-import konkuk.kuit.baro.domain.vote.model.PromisePlaceVoteHistory;
 import konkuk.kuit.baro.global.common.model.BaseEntity;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -33,11 +32,6 @@ public class PromiseSuggestedPlace extends BaseEntity {
     @JoinColumn(name = "place_id", nullable = false)
     private Place place;
 
-    // 제안된 약속 장소 삭제시, 약속 장소 투표 내역도 사라지도록 하기 위한 양방향 연관 관계
-    @OneToMany(mappedBy = "promiseSuggestedPlace", orphanRemoval = true)
-    private List<PromisePlaceVoteHistory> promisePlaceVoteHistories = new ArrayList<>();
-
-
     // 생성 메서드
     public static PromiseSuggestedPlace createPromiseSuggestedPlace(PromiseMember promiseMember, Place place) {
         PromiseSuggestedPlace promiseSuggestedPlace = new PromiseSuggestedPlace();
@@ -56,9 +50,5 @@ public class PromiseSuggestedPlace extends BaseEntity {
     private void setPlace(Place place) {
         this.place = place;
         place.addPromiseSuggestedPlace(this);
-    }
-
-    public void addPromisePlaceVoteHistory(PromisePlaceVoteHistory promisePlaceVoteHistory) {
-        this.promisePlaceVoteHistories.add(promisePlaceVoteHistory);
     }
 }

--- a/src/main/java/konkuk/kuit/baro/domain/promise/repository/PromiseCandidatePlaceRepository.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/repository/PromiseCandidatePlaceRepository.java
@@ -1,0 +1,9 @@
+package konkuk.kuit.baro.domain.promise.repository;
+
+import konkuk.kuit.baro.domain.promise.model.PromiseCandidatePlace;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PromiseCandidatePlaceRepository extends JpaRepository<PromiseCandidatePlace, Long> {
+}

--- a/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
@@ -1,6 +1,7 @@
 package konkuk.kuit.baro.domain.promise.service;
 
 import konkuk.kuit.baro.domain.place.model.Place;
+import konkuk.kuit.baro.domain.place.repository.PlaceRepository;
 import konkuk.kuit.baro.domain.promise.dto.request.PromiseSuggestRequestDTO;
 import konkuk.kuit.baro.domain.promise.dto.response.PendingPromiseResponseDTO;
 import konkuk.kuit.baro.domain.promise.dto.response.PromiseMemberSuggestStateDTO;
@@ -28,13 +29,10 @@ import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.Collections;
+import java.util.*;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.temporal.ChronoUnit;
-import java.util.List;
+import java.util.stream.Collectors;
 
 import static konkuk.kuit.baro.domain.promise.dto.response.SuggestionProgress.*;
 
@@ -50,6 +48,7 @@ public class PromiseService {
     private final PromiseAvailableTimeRepository promiseAvailableTimeRepository;
     private final PromiseSuggestedPlaceRepository promiseSuggestedPlaceRepository;
     private final PromiseTimeVoteHistoryRepository promiseTimeVoteHistoryRepository;
+    private final PlaceRepository placeRepository;
 
     private final ColorUtil colorUtil;
 
@@ -118,7 +117,8 @@ public class PromiseService {
                 case PENDING -> suggestedPromises.add(mapToSuggestedPromiseDTO(promise));
                 case VOTING -> votingPromises.add(mapToVotingPromiseDTO(promise));
                 case CONFIRMED -> confirmedPromises.add(mapToConfirmedPromiseDTO(promise));
-                case ACTIVE -> {}
+                case ACTIVE -> {
+                }
                 default -> throw new IllegalArgumentException();
             }
         }
@@ -222,6 +222,33 @@ public class PromiseService {
         return new HasVotedResponseDTO(extractHasVoted(findPromiseVote, findPromiseMember));
     }
 
+    // 투표 후보 목록 조회
+    public VoteCandidateListResponseDTO getVoteCandidateList(Long userId, Long promiseId, boolean hasVoted) {
+        Promise findPromise = findPromise(promiseId);
+        PromiseVote findPromiseVote = findPromiseVote(findPromise);
+        PromiseMember findPromiseMember = findPromiseMember(userId, promiseId);
+
+        // 투표한 경우, 사용자가 선택한 약속 후보 시간 및 약속 후보 장소 ID 가져오기
+        final Set<Long> selectedTimeIds = hasVoted
+                ? findPromiseMember.getPromiseTimeVoteHistories().stream()
+                .map(voteHistory -> voteHistory.getPromiseCandidateTime().getId())
+                .collect(Collectors.toSet())
+                : Collections.emptySet();
+
+        final Set<Long> selectedPlaceIds = hasVoted
+                ? findPromiseMember.getPromisePlaceVoteHistories().stream()
+                .map(voteHistory -> voteHistory.getPromiseCandidatePlace().getId())
+                .collect(Collectors.toSet())
+                : Collections.emptySet();
+
+        // 모든 후보 시간 리스트 생성 (투표 여부 반영)
+        List<CandidateTimesDTO> candidateTimes = getCandidateTimesList(hasVoted, findPromiseVote, selectedTimeIds);
+
+        // 모든 후보 장소 리스트 생성 (투표 여부 반영)
+        List<CandidatePlacesDTO> candidatePlaces = getCandidatePlacesList(hasVoted, findPromiseVote, selectedPlaceIds);
+
+        return new VoteCandidateListResponseDTO(candidateTimes, candidatePlaces);
+    }
 
     private User findLoginUser(Long userId) {
         return userRepository.findById(userId)
@@ -367,6 +394,30 @@ public class PromiseService {
                 )).toList();
     }
 
+    // 투표 후보 장소 목록 반환
+    private List<CandidatePlacesDTO> getCandidatePlacesList(boolean hasVoted, PromiseVote findPromiseVote, Set<Long> selectedPlaceIds) {
+        return findPromiseVote.getPromiseCandidatePlaces()
+                .stream()
+                .map(promiseCandidatePlace -> new CandidatePlacesDTO(
+                        promiseCandidatePlace.getId(),
+                        promiseCandidatePlace.getPlace().getPlaceName(),
+                        hasVoted && selectedPlaceIds.contains(promiseCandidatePlace.getId()) // 투표했으면 true
+                ))
+                .toList();
+    }
+
+    // 투표 후보 시간 목록 반환
+    private List<CandidateTimesDTO> getCandidateTimesList(boolean hasVoted, PromiseVote findPromiseVote, Set<Long> selectedTimeIds) {
+        return findPromiseVote.getPromiseCandidateTimes()
+                .stream()
+                .map(promiseCandidateTime -> new CandidateTimesDTO(
+                        promiseCandidateTime.getId(),
+                        DateUtil.formatDate(promiseCandidateTime.getPromiseCandidateTimeDate()),
+                        DateUtil.formatTime(promiseCandidateTime.getPromiseCandidateTimeStartTime()),
+                        hasVoted && selectedTimeIds.contains(promiseCandidateTime.getId()) // 투표했으면 true
+                ))
+                .toList();
+    }
 
 
 }

--- a/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
@@ -213,6 +213,15 @@ public class PromiseService {
         return new PromiseVoteRemainingTimeResponseDTO(DateUtil.getRemainingTimeUntilEndDate(findPromiseVote.getVoteEndTime()));
     }
 
+    // 특정 약속 참여자의 투표 참여 여부 반환
+    public HasVotedResponseDTO getHasVoted(Long userId, Long promiseId) {
+        Promise findPromise = findPromise(promiseId);
+        PromiseMember findPromiseMember = findPromiseMember(userId, promiseId);
+        PromiseVote findPromiseVote = findPromiseVote(findPromise);
+
+        return new HasVotedResponseDTO(extractHasVoted(findPromiseVote, findPromiseMember));
+    }
+
 
     private User findLoginUser(Long userId) {
         return userRepository.findById(userId)

--- a/src/main/java/konkuk/kuit/baro/domain/vote/model/PromisePlaceVoteHistory.java
+++ b/src/main/java/konkuk/kuit/baro/domain/vote/model/PromisePlaceVoteHistory.java
@@ -1,6 +1,8 @@
 package konkuk.kuit.baro.domain.vote.model;
 
 import jakarta.persistence.*;
+import konkuk.kuit.baro.domain.promise.model.PromiseCandidatePlace;
+import konkuk.kuit.baro.domain.promise.model.PromiseCandidateTime;
 import konkuk.kuit.baro.domain.promise.model.PromiseMember;
 import konkuk.kuit.baro.domain.promise.model.PromiseSuggestedPlace;
 import konkuk.kuit.baro.global.common.model.BaseEntity;
@@ -24,8 +26,8 @@ public class PromisePlaceVoteHistory extends BaseEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "promise_suggested_place_id", nullable = false)
-    private PromiseSuggestedPlace promiseSuggestedPlace;
+    @JoinColumn(name = "promise_candidate_place_id", nullable = false)
+    private PromiseCandidatePlace promiseCandidatePlace;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "promise_vote_id", nullable = false)
@@ -36,18 +38,17 @@ public class PromisePlaceVoteHistory extends BaseEntity {
     private PromiseMember promiseMember;
 
     // 생성 메서드
-    public static PromisePlaceVoteHistory createPromisePlaceVoteHistory(PromiseSuggestedPlace promiseSuggestedPlace, PromiseVote promiseVote, PromiseMember promiseMember) {
+    public static PromisePlaceVoteHistory createPromisePlaceVoteHistory(PromiseCandidatePlace promiseCandidatePlace, PromiseVote promiseVote, PromiseMember promiseMember) {
         PromisePlaceVoteHistory promisePlaceVoteHistory = new PromisePlaceVoteHistory();
-        promisePlaceVoteHistory.setPromiseSuggestedPlace(promiseSuggestedPlace);
+        promisePlaceVoteHistory.setPromiseCandidatePlace(promiseCandidatePlace);
         promisePlaceVoteHistory.setPromiseVote(promiseVote);
         promisePlaceVoteHistory.setPromiseMember(promiseMember);
         return promisePlaceVoteHistory;
     }
 
-    // 연관 관계 편의 메서드
-    private void setPromiseSuggestedPlace(PromiseSuggestedPlace promiseSuggestedPlace) {
-        this.promiseSuggestedPlace = promiseSuggestedPlace;
-        promiseSuggestedPlace.addPromisePlaceVoteHistory(this);
+    private void setPromiseCandidatePlace(PromiseCandidatePlace promiseCandidatePlace) {
+        this.promiseCandidatePlace = promiseCandidatePlace;
+        promiseCandidatePlace.addPromisePlaceVoteHistory(this);
     }
 
     private void setPromiseVote(PromiseVote promiseVote) {

--- a/src/main/java/konkuk/kuit/baro/domain/vote/model/PromiseVote.java
+++ b/src/main/java/konkuk/kuit/baro/domain/vote/model/PromiseVote.java
@@ -1,6 +1,7 @@
 package konkuk.kuit.baro.domain.vote.model;
 
 import jakarta.persistence.*;
+import konkuk.kuit.baro.domain.promise.model.PromiseCandidatePlace;
 import konkuk.kuit.baro.domain.promise.model.PromiseCandidateTime;
 import konkuk.kuit.baro.global.common.model.BaseEntity;
 import lombok.*;
@@ -29,12 +30,16 @@ public class PromiseVote extends BaseEntity {
     private List<PromiseTimeVoteHistory> promiseTimeVoteHistories = new ArrayList<>();
 
     // 투표된 장소들을 확인하기 위한 양방향 연관 관계
-    @OneToMany(mappedBy = "promiseVote", orphanRemoval = true)
+    @OneToMany(mappedBy = "promiseVote")
     private List<PromisePlaceVoteHistory> promisePlaceVoteHistories = new ArrayList<>();
 
     // 약속 후보 시간들을 확인하기 위한 양방향 연관 관계
     @OneToMany(mappedBy = "promiseVote", orphanRemoval = true)
     private List<PromiseCandidateTime> promiseCandidateTimes = new ArrayList<>();
+
+    // 약속 후보 장소들을 확인하기 위한 양방향 연관 관계
+    @OneToMany(mappedBy = "promiseVote", orphanRemoval = true)
+    private List<PromiseCandidatePlace> promiseCandidatePlaces = new ArrayList<>();
 
     @Builder
     public PromiseVote(LocalDateTime voteEndTime) {
@@ -52,5 +57,9 @@ public class PromiseVote extends BaseEntity {
 
     public void addPromiseCandidateTime(PromiseCandidateTime promiseCandidateTime) {
         this.promiseCandidateTimes.add(promiseCandidateTime);
+    }
+
+    public void addPromiseCandidatePlace(PromiseCandidatePlace promiseCandidatePlace) {
+        this.promiseCandidatePlaces.add(promiseCandidatePlace);
     }
 }

--- a/src/main/java/konkuk/kuit/baro/global/common/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/kuit/baro/global/common/config/swagger/SwaggerResponseDescription.java
@@ -126,6 +126,13 @@ public enum SwaggerResponseDescription {
             PROMISE_NOT_FOUND,
             PROMISE_MEMBER_NOT_FOUND,
             PROMISE_VOTE_NOT_STARTED
+    ))),
+
+    VOTE_CANDIDATE_LIST(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND,
+            PROMISE_NOT_FOUND,
+            PROMISE_MEMBER_NOT_FOUND,
+            PROMISE_VOTE_NOT_STARTED
     )));
 
     private final Set<ErrorCode> errorCodeList;

--- a/src/main/java/konkuk/kuit/baro/global/common/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/kuit/baro/global/common/config/swagger/SwaggerResponseDescription.java
@@ -119,6 +119,13 @@ public enum SwaggerResponseDescription {
             PROMISE_NOT_FOUND,
             PROMISE_VOTE_NOT_STARTED,
             TIME_EXCEED
+    ))),
+
+    PROMISE_MEMBER_HAS_VOTED(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND,
+            PROMISE_NOT_FOUND,
+            PROMISE_MEMBER_NOT_FOUND,
+            PROMISE_VOTE_NOT_STARTED
     )));
 
     private final Set<ErrorCode> errorCodeList;

--- a/src/main/java/konkuk/kuit/baro/global/common/util/DateUtil.java
+++ b/src/main/java/konkuk/kuit/baro/global/common/util/DateUtil.java
@@ -5,6 +5,8 @@ import konkuk.kuit.baro.global.common.response.status.ErrorCode;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 
 
@@ -46,6 +48,17 @@ public class DateUtil {
         }
 
         return time.toString().trim();
+    }
+
+    // 날짜를 "yyyy년 M월 D일" 형식으로 변환
+    public static String formatDate(LocalDate date) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("M월 d일");
+        return date.format(formatter);
+    }
+
+    public static String formatTime(LocalTime time) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
+        return time.format(formatter);
     }
 }
 

--- a/src/test/java/konkuk/kuit/baro/domain/promise/repository/PromiseCandidatePlaceRepositoryTest.java
+++ b/src/test/java/konkuk/kuit/baro/domain/promise/repository/PromiseCandidatePlaceRepositoryTest.java
@@ -1,4 +1,185 @@
+package konkuk.kuit.baro.domain.promise.repository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import konkuk.kuit.baro.domain.place.model.Place;
+import konkuk.kuit.baro.domain.place.repository.PlaceRepository;
+import konkuk.kuit.baro.domain.promise.model.Promise;
+import konkuk.kuit.baro.domain.promise.model.PromiseCandidatePlace;
+import konkuk.kuit.baro.domain.promise.model.PromiseCandidateTime;
+import konkuk.kuit.baro.domain.promise.model.PromiseMember;
+import konkuk.kuit.baro.domain.user.model.User;
+import konkuk.kuit.baro.domain.user.repository.UserRepository;
+import konkuk.kuit.baro.domain.vote.model.PromiseVote;
+import konkuk.kuit.baro.domain.vote.repository.PromiseVoteRepository;
+import konkuk.kuit.baro.global.common.util.GeometryUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Description;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
 class PromiseCandidatePlaceRepositoryTest {
-  
+
+    @Autowired
+    private PromiseRepository promiseRepository;
+    @Autowired
+    private PromiseMemberRepository promiseMemberRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private PlaceRepository placeRepository;
+    @Autowired
+    private PromiseCandidatePlaceRepository promiseCandidatePlaceRepository;
+    @Autowired
+    private PromiseVoteRepository promiseVoteRepository;
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @BeforeEach
+    void init() {
+        User user = User.builder()
+                .email("hong@konkuk.ac.kr")
+                .name("홍길동")
+                .password("qwer1234!")
+                .profileImage("image.png")
+                .build();
+
+        userRepository.save(user);
+
+        Promise promise = Promise.builder()
+                .promiseName("컴퓨터 공학부 개강파티")
+                .suggestedRegion("지그재그")
+                .suggestedStartDate(LocalDate.now().minusDays(1))
+                .suggestedEndDate(LocalDate.now().plusDays(1))
+                .build();
+
+        Promise savedPromise = promiseRepository.save(promise);
+
+        PromiseMember promiseMember = PromiseMember.createPromiseMember(true, "#F4F4F4", user, promise);
+
+        promiseMemberRepository.save(promiseMember);
+
+        PromiseVote promiseVote = PromiseVote.builder()
+                .voteEndTime(LocalDateTime.now())
+                .build();
+
+        PromiseVote savedPromiseVote = promiseVoteRepository.save(promiseVote);
+
+        savedPromise.setPromiseVote(savedPromiseVote);
+
+        Place place = Place.builder()
+                .placeName("스타벅스 건대점")
+                .location(GeometryUtil.createPoint(122.4194155, 37.1231213))
+                .placeAddress("광진구 화양동")
+                .build();
+
+        // when
+        placeRepository.save(place);
+    }
+
+    @Test
+    @DisplayName("약속 후보 장소 저장 테스트")
+    void save() {
+        // given
+        PromiseVote promiseVote = promiseVoteRepository.findById(1L).get();
+        Place place = placeRepository.findById(1L).get();
+        PromiseCandidatePlace promiseCandidatePlace = PromiseCandidatePlace.createPromiseCandidatePlace(promiseVote, place);
+
+        // when
+        promiseCandidatePlaceRepository.save(promiseCandidatePlace);
+
+        // then
+        assertThat(promiseCandidatePlaceRepository.findById(1L).isPresent()).isTrue();
+    }
+
+    @Test
+    @DisplayName("약속 후보 장소 삭제 테스트")
+    void delete() {
+        // given
+        PromiseVote promiseVote = promiseVoteRepository.findById(1L).get();
+        Place place = placeRepository.findById(1L).get();
+        PromiseCandidatePlace promiseCandidatePlace = PromiseCandidatePlace.createPromiseCandidatePlace(promiseVote, place);
+
+        promiseCandidatePlaceRepository.save(promiseCandidatePlace);
+
+        em.flush();
+        em.clear();
+
+        // when
+        PromiseCandidatePlace findPromiseCandidatePlace = promiseCandidatePlaceRepository.findById(1L).get();
+        promiseCandidatePlaceRepository.delete(findPromiseCandidatePlace);
+
+        em.flush();
+        em.clear();
+
+        // then
+        assertThat(promiseCandidatePlaceRepository.findById(1L).isEmpty()).isTrue();
+    }
+
+    @Test
+    @DisplayName("약속 후보 장소 삭제 테스트")
+    @Description("약속을 삭제했을 때, 약속 후보 장소도 삭제되는지 테스트. 약속 삭제 -> 약속 투표 삭제 -> 약속 후보 장소 삭제")
+    void delete_promise() {
+        // given
+        PromiseVote promiseVote = promiseVoteRepository.findById(1L).get();
+        Place place = placeRepository.findById(1L).get();
+        PromiseCandidatePlace promiseCandidatePlace = PromiseCandidatePlace.createPromiseCandidatePlace(promiseVote, place);
+
+        promiseCandidatePlaceRepository.save(promiseCandidatePlace);
+
+        em.flush();
+        em.clear();
+
+        // when
+        Promise findPromise = promiseRepository.findById(1L).get();
+        promiseRepository.delete(findPromise);
+
+        em.flush();
+        em.clear();
+
+        // then
+        assertThat(promiseCandidatePlaceRepository.findById(1L).isEmpty()).isTrue();
+
+    }
+
+    @Test
+    @DisplayName("약속 후보 장소 삭제 테스트")
+    @Description("장소를 삭제했을 때, 약속 후보 장소도 삭제되는지 테스트. 장소 삭제 -> 약속 후보 장소 삭제")
+    void delete_place() {
+        // given
+        PromiseVote promiseVote = promiseVoteRepository.findById(1L).get();
+        Place place = placeRepository.findById(1L).get();
+        PromiseCandidatePlace promiseCandidatePlace = PromiseCandidatePlace.createPromiseCandidatePlace(promiseVote, place);
+
+        promiseCandidatePlaceRepository.save(promiseCandidatePlace);
+
+        em.flush();
+        em.clear();
+
+        // when
+        Place findPlace = placeRepository.findById(1L).get();
+        placeRepository.delete(findPlace);
+
+        em.flush();
+        em.clear();
+
+        // then
+        assertThat(promiseCandidatePlaceRepository.findById(1L).isEmpty()).isTrue();
+
+    }
+
 }

--- a/src/test/java/konkuk/kuit/baro/domain/promise/repository/PromiseCandidatePlaceRepositoryTest.java
+++ b/src/test/java/konkuk/kuit/baro/domain/promise/repository/PromiseCandidatePlaceRepositoryTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class PromiseCandidatePlaceRepositoryTest {
+  
+}

--- a/src/test/java/konkuk/kuit/baro/domain/promise/service/PromiseServiceTest.java
+++ b/src/test/java/konkuk/kuit/baro/domain/promise/service/PromiseServiceTest.java
@@ -6,12 +6,19 @@ import konkuk.kuit.baro.domain.place.model.Place;
 import konkuk.kuit.baro.domain.place.repository.PlaceRepository;
 import konkuk.kuit.baro.domain.promise.dto.response.ConfirmedPromiseResponseDTO;
 import konkuk.kuit.baro.domain.promise.dto.response.PromiseStatusConfirmedPromiseResponseDTO;
-import konkuk.kuit.baro.domain.promise.model.Promise;
-import konkuk.kuit.baro.domain.promise.repository.PromiseRepository;
+import konkuk.kuit.baro.domain.promise.model.*;
+import konkuk.kuit.baro.domain.promise.repository.*;
+import konkuk.kuit.baro.domain.user.model.User;
+import konkuk.kuit.baro.domain.user.repository.UserRepository;
+import konkuk.kuit.baro.domain.vote.model.PromisePlaceVoteHistory;
+import konkuk.kuit.baro.domain.vote.model.PromiseTimeVoteHistory;
 import konkuk.kuit.baro.domain.vote.model.PromiseVote;
+import konkuk.kuit.baro.domain.vote.repository.PromisePlaceVoteHistoryRepository;
+import konkuk.kuit.baro.domain.vote.repository.PromiseTimeVoteHistoryRepository;
 import konkuk.kuit.baro.domain.vote.repository.PromiseVoteRepository;
 import konkuk.kuit.baro.global.common.exception.CustomException;
 import konkuk.kuit.baro.global.common.response.status.ErrorCode;
+import konkuk.kuit.baro.global.common.util.DateUtil;
 import konkuk.kuit.baro.global.common.util.GeometryUtil;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -34,19 +41,34 @@ import static org.junit.jupiter.api.Assertions.*;
 class PromiseServiceTest {
 
     @Autowired
+    PromiseMemberRepository promiseMemberRepository;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
     private PromiseRepository promiseRepository;
     @Autowired
     private PlaceRepository placeRepository;
+    @Autowired
+    PromiseSuggestedPlaceRepository promiseSuggestedPlaceRepository;
+    @Autowired
+    PromiseCandidatePlaceRepository promiseCandidatePlaceRepository;
+    @Autowired
+    PromiseCandidateTimeRepository promiseCandidateTimeRepository;
+    @Autowired
+    PromiseTimeVoteHistoryRepository promiseTimeVoteHistoryRepository;
+    @Autowired
+    PromisePlaceVoteHistoryRepository promisePlaceVoteHistoryRepository;
 
-    @Autowired private PromiseService promiseService;
-    @Autowired private PromiseVoteRepository promiseVoteRepository;
+    @Autowired
+    private PromiseService promiseService;
+    @Autowired
+    private PromiseVoteRepository promiseVoteRepository;
 
     @PersistenceContext
     private EntityManager em;
 
     @Test
     @DisplayName("약속 현황 - 확정 테스트")
-    @Rollback(value = false)
     void confirm() {
         // given
         Promise promise = Promise.builder()
@@ -222,5 +244,103 @@ class PromiseServiceTest {
                 .isInstanceOf(CustomException.class)
                 .hasMessage(ErrorCode.TIME_EXCEED.getMessage());
     }
+
+    @Test
+    @DisplayName("투표 후보 목록 조회 테스트")
+    void getVoteCandidateList() {
+        // given: 사용자 및 약속 생성
+        User user = User.builder()
+                .email("hong@konkuk.ac.kr")
+                .name("홍길동")
+                .password("qwer1234!")
+                .profileImage("image.png")
+                .build();
+        userRepository.save(user);
+
+        Promise promise = Promise.builder()
+                .promiseName("컴퓨터 공학부 개강파티")
+                .suggestedRegion("지그재그")
+                .suggestedStartDate(LocalDate.now().minusDays(1))
+                .suggestedEndDate(LocalDate.now().plusDays(1))
+                .build();
+        promiseRepository.save(promise);
+
+        em.flush();
+        em.clear();
+
+        // given: 약속 멤버 생성
+        User findUser = userRepository.findById(1L).get();
+        Promise findPromise = promiseRepository.findById(1L).get();
+
+        PromiseMember promiseMember = PromiseMember.createPromiseMember(true, "#F4F4F4", findUser, findPromise);
+        promiseMemberRepository.save(promiseMember);
+
+        // given: 장소 및 제안된 장소 생성
+        Place place = Place.builder()
+                .placeName("스타벅스 건대점")
+                .location(GeometryUtil.createPoint(37.7749295, 122.4194155))
+                .placeAddress("광진구 화양동")
+                .build();
+        placeRepository.save(place);
+
+        em.flush();
+        em.clear();
+
+        // given: 투표 데이터 생성
+        PromiseMember findPromiseMember = promiseMemberRepository.findById(1L).get();
+        Place findPlace = placeRepository.findById(1L).orElseThrow();
+
+        PromiseSuggestedPlace promiseSuggestedPlace = PromiseSuggestedPlace.createPromiseSuggestedPlace(findPromiseMember, findPlace);
+        promiseSuggestedPlaceRepository.save(promiseSuggestedPlace);
+
+        // given: 약속 투표 생성
+        PromiseVote promiseVote = PromiseVote.builder()
+                .voteEndTime(LocalDateTime.now())
+                .build();
+        promiseVoteRepository.save(promiseVote);
+
+        findPromise = promiseRepository.findById(1L).get();
+        findPromise.setPromiseVote(promiseVote);
+        em.flush();
+        em.clear();
+
+        // given: 투표 후보 장소 및 시간 생성
+        PromiseVote findPromiseVote = promiseVoteRepository.findById(1L).get();
+        findPlace = placeRepository.findById(1L).get();
+        PromiseCandidatePlace promiseCandidatePlace = PromiseCandidatePlace.createPromiseCandidatePlace(findPromiseVote, findPlace);
+        promiseCandidatePlaceRepository.save(promiseCandidatePlace);
+
+        PromiseCandidateTime promiseCandidateTime = PromiseCandidateTime.createPromiseCandidateTime(
+                LocalDate.of(2025, 7, 3), LocalTime.now(), findPromiseVote);
+        promiseCandidateTimeRepository.save(promiseCandidateTime);
+
+        em.flush();
+        em.clear();
+
+        // when: 사용자가 실제로 투표한 기록 추가
+        PromiseCandidateTime findPromiseCandidateTime = promiseCandidateTimeRepository.findById(1L).get();
+        PromiseCandidatePlace findPromiseCandidatePlace = promiseCandidatePlaceRepository.findById(1L).get();
+        findPromiseVote = promiseVoteRepository.findById(1L).get();
+        findPromiseMember = promiseMemberRepository.findById(1L).get();
+
+        PromiseTimeVoteHistory promiseTimeVoteHistory = PromiseTimeVoteHistory.createPromiseTimeVoteHistory(
+                findPromiseVote, findPromiseCandidateTime, findPromiseMember);
+        promiseTimeVoteHistoryRepository.save(promiseTimeVoteHistory);
+
+        PromisePlaceVoteHistory promisePlaceVoteHistory = PromisePlaceVoteHistory.createPromisePlaceVoteHistory(
+                findPromiseCandidatePlace, findPromiseVote, findPromiseMember);
+        promisePlaceVoteHistoryRepository.save(promisePlaceVoteHistory);
+
+        em.flush();
+        em.clear();
+
+        assertThat(promiseService.getVoteCandidateList(1L, 1L, true).getCandidateTimes().get(0).getIsSelected()).isTrue();
+        assertThat(promiseService.getVoteCandidateList(1L, 1L, true).getCandidateTimes().get(0).getDate()).isEqualTo(DateUtil.formatDate(LocalDate.of(2025, 7, 3)));
+
+        assertThat(promiseService.getVoteCandidateList(1L, 1L, true).getCandidatePlaces().get(0).getIsSelected()).isTrue();
+        assertThat(promiseService.getVoteCandidateList(1L, 1L, true).getCandidatePlaces().get(0).getPlaceName()).isEqualTo("스타벅스 건대점");
+
+    }
+
 
 }

--- a/src/test/java/konkuk/kuit/baro/domain/vote/repository/PromisePlaceVoteHistoryRepositoryTest.java
+++ b/src/test/java/konkuk/kuit/baro/domain/vote/repository/PromisePlaceVoteHistoryRepositoryTest.java
@@ -5,8 +5,10 @@ import jakarta.persistence.PersistenceContext;
 import konkuk.kuit.baro.domain.place.model.Place;
 import konkuk.kuit.baro.domain.place.repository.PlaceRepository;
 import konkuk.kuit.baro.domain.promise.model.Promise;
+import konkuk.kuit.baro.domain.promise.model.PromiseCandidatePlace;
 import konkuk.kuit.baro.domain.promise.model.PromiseMember;
 import konkuk.kuit.baro.domain.promise.model.PromiseSuggestedPlace;
+import konkuk.kuit.baro.domain.promise.repository.PromiseCandidatePlaceRepository;
 import konkuk.kuit.baro.domain.promise.repository.PromiseMemberRepository;
 import konkuk.kuit.baro.domain.promise.repository.PromiseRepository;
 import konkuk.kuit.baro.domain.promise.repository.PromiseSuggestedPlaceRepository;
@@ -54,6 +56,8 @@ class PromisePlaceVoteHistoryRepositoryTest {
 
     @PersistenceContext
     private EntityManager em;
+    @Autowired
+    private PromiseCandidatePlaceRepository promiseCandidatePlaceRepository;
 
     @BeforeEach
     void init() {
@@ -96,20 +100,21 @@ class PromisePlaceVoteHistoryRepositoryTest {
 
         promiseVoteRepository.save(promiseVote);
 
-        em.flush();
-        em.clear();
+        PromiseCandidatePlace promiseCandidatePlace = PromiseCandidatePlace.createPromiseCandidatePlace(promiseVote, place);
+
+        promiseCandidatePlaceRepository.save(promiseCandidatePlace);
     }
 
     @Test
     @DisplayName("약속 장소 투표 내역 저장 테스트")
     void save() {
         // given
-        PromiseSuggestedPlace promiseSuggestedPlace = promiseSuggestedPlaceRepository.findById(1L).get();
         PromiseVote promiseVote = promiseVoteRepository.findById(1L).get();
         PromiseMember promiseMember = promiseMemberRepository.findById(1L).get();
+        PromiseCandidatePlace promiseCandidatePlace = promiseCandidatePlaceRepository.findById(1L).get();
 
         // when
-        PromisePlaceVoteHistory promisePlaceVoteHistory = PromisePlaceVoteHistory.createPromisePlaceVoteHistory(promiseSuggestedPlace, promiseVote, promiseMember);
+        PromisePlaceVoteHistory promisePlaceVoteHistory = PromisePlaceVoteHistory.createPromisePlaceVoteHistory(promiseCandidatePlace, promiseVote, promiseMember);
 
         promisePlaceVoteHistoryRepository.save(promisePlaceVoteHistory);
 
@@ -124,11 +129,11 @@ class PromisePlaceVoteHistoryRepositoryTest {
     @DisplayName("약속 장소 투표 내역 삭제 테스트")
     void delete() {
         // given
-        PromiseSuggestedPlace promiseSuggestedPlace = promiseSuggestedPlaceRepository.findById(1L).get();
         PromiseVote promiseVote = promiseVoteRepository.findById(1L).get();
         PromiseMember promiseMember = promiseMemberRepository.findById(1L).get();
+        PromiseCandidatePlace promiseCandidatePlace = promiseCandidatePlaceRepository.findById(1L).get();
 
-        PromisePlaceVoteHistory promisePlaceVoteHistory = PromisePlaceVoteHistory.createPromisePlaceVoteHistory(promiseSuggestedPlace, promiseVote, promiseMember);
+        PromisePlaceVoteHistory promisePlaceVoteHistory = PromisePlaceVoteHistory.createPromisePlaceVoteHistory(promiseCandidatePlace, promiseVote, promiseMember);
 
         promisePlaceVoteHistoryRepository.save(promisePlaceVoteHistory);
 
@@ -148,17 +153,17 @@ class PromisePlaceVoteHistoryRepositoryTest {
 
     @Test
     @DisplayName("약속 장소 투표 내역 삭제 테스트")
-    @Description("약속을 삭제했을 때, 약속 장소 투표 내역도 삭제되는 지 테스트. 약속 삭제 -> 약속 투표 삭제 -> 약속 장소 투표 내역 삭제")
+    @Description("약속을 삭제했을 때, 약속 장소 투표 내역도 삭제되는 지 테스트. 약속 삭제 -> 약속 투표 삭제 -> 약속 후보 장소 삭제 -> 약속 장소 투표 내역 삭제")
     void delete_promise() {
         // given
-        PromiseSuggestedPlace promiseSuggestedPlace = promiseSuggestedPlaceRepository.findById(1L).get();
         PromiseVote promiseVote = promiseVoteRepository.findById(1L).get();
         Promise promise = promiseRepository.findById(1L).get();
         PromiseMember promiseMember = promiseMemberRepository.findById(1L).get();
+        PromiseCandidatePlace promiseCandidatePlace = promiseCandidatePlaceRepository.findById(1L).get();
 
         promise.setPromiseVote(promiseVote);
 
-        PromisePlaceVoteHistory promisePlaceVoteHistory = PromisePlaceVoteHistory.createPromisePlaceVoteHistory(promiseSuggestedPlace, promiseVote, promiseMember);
+        PromisePlaceVoteHistory promisePlaceVoteHistory = PromisePlaceVoteHistory.createPromisePlaceVoteHistory(promiseCandidatePlace, promiseVote, promiseMember);
 
         promisePlaceVoteHistoryRepository.save(promisePlaceVoteHistory);
 
@@ -182,14 +187,14 @@ class PromisePlaceVoteHistoryRepositoryTest {
     @Description("유저를 삭제했을 때, 약속 장소 투표 내역도 삭제되는 지 테스트. 유저 삭제 -> 약속 참여자 삭제 -> 약속 장소 투표 내역 삭제")
     void delete_User() {
         // given
-        PromiseSuggestedPlace promiseSuggestedPlace = promiseSuggestedPlaceRepository.findById(1L).get();
         PromiseVote promiseVote = promiseVoteRepository.findById(1L).get();
         Promise promise = promiseRepository.findById(1L).get();
         PromiseMember promiseMember = promiseMemberRepository.findById(1L).get();
+        PromiseCandidatePlace promiseCandidatePlace = promiseCandidatePlaceRepository.findById(1L).get();
 
         promise.setPromiseVote(promiseVote);
 
-        PromisePlaceVoteHistory promisePlaceVoteHistory = PromisePlaceVoteHistory.createPromisePlaceVoteHistory(promiseSuggestedPlace, promiseVote, promiseMember);
+        PromisePlaceVoteHistory promisePlaceVoteHistory = PromisePlaceVoteHistory.createPromisePlaceVoteHistory(promiseCandidatePlace, promiseVote, promiseMember);
 
         promisePlaceVoteHistoryRepository.save(promisePlaceVoteHistory);
 


### PR DESCRIPTION
## Related issue 🛠
- closed #50 

## Work Description 📝

### ERD 수정
ERD에 일부 수정이 발생했습니다. 제안된 약속 장소, 장소, 약속 장소 투표 내역 등의 테이블에 수정이 발생했으며, 새롭게 약속 후보 장소 라는 테이블이 생겨났습니다. 제가 현재 구현중인 약속 현황 / 투표 로직을 제외하고는 사용하는 곳이 없어서 별도의 코드 수정이 추가로 필요하지는 않을 것 같습니다.
우선 기존에는 제안된 약속 장소 테이블과 약속 장소 투표 내역 테이블이 곧바로 연관관계를 갖고있었습니다. 그러다보니 제안된 약속 장소 목록에서 투표에 후보로 보여줄 항목들을 고를 때, 매번 DB를 조회하면서 빈도 수 기준으로 상위 3개의 레코드를 조회해와야하는 번거로움이 존재했습니다. 또한 기능상으로 생각해보았을 때, 사용자가 이미 투표를 완료한 상태로 다시 투표하기 버튼을 누르게되면, 기존에 투표했던 투표 후보 목록을 표시해주어야하는데, 이 때 제안된 약속 장소 데이터에서 뽑아낸 상위 3개의 데이터를 매번 조회해서 보여주어야했습니다.  저장해두고 사용하는 것이 아니라, 그 때 그 때 DB에서 count 쿼리를 날리고 조회를 하는 것이 어색하게 느껴졌고, 뭔가 불필요한 과정, 비효율적인 부분이 많다고 판단해서 새롭게 약속 후보 장소 테이블을 만들었습니다.

이 테이블은, 투표가 시작되는 시점에, 제안된 약속 장소들 중 가장 많이 선택된 장소 순으로 상위 3개를 찾아서 저장해둡니다. 즉 특정 약속에 대해 어떤 장소들을 후보로 보여줄 것인지를 저장하는 테이블입니다.

이 테이블에도 마찬가지로 CASCADE 를 적용해주어서 저장, 삭제가 문제없이 되는 것은 확인하였습니다.


### 투표 목록 조회
투표 목록을 조회합니다. 앞서 말한 것 처럼 약속 후보 장소 테이블을 만들어둠에 따라서, 약속 후보 시간, 약속 후보 장소 테이블을 확인하며, 특정 약속에 대한 후보 시간대, 후보 장소들을 조회해 출력해줍니다.



## Screenshot 📸

기존 형태 (약속 참여자 -> 약속 장소 투표 내역 간의 연관관계는 누락되어 보이는 상황)
<img width="1286" alt="스크린샷 2025-04-04 오전 12 59 14" src="https://github.com/user-attachments/assets/ace974d2-b11d-4d60-bff7-f73091401a78" />

새로운 형태 
<img width="995" alt="스크린샷 2025-04-04 오전 12 57 01" src="https://github.com/user-attachments/assets/b95e3ab6-4caf-45b1-a30f-8fc367204de5" />

## Uncompleted Tasks 😅

## To Reviewers 📢
