### PR TITLE
[Feat] 투표하기 & 투표 시작 및 종료 기능 구현

### DIFF
--- a/src/main/java/konkuk/kuit/baro/domain/promise/controller/PromiseController.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/controller/PromiseController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import konkuk.kuit.baro.domain.promise.dto.request.PromiseSuggestRequestDTO;
+import konkuk.kuit.baro.domain.promise.dto.request.PromiseVoteRequestDTO;
 import konkuk.kuit.baro.domain.promise.dto.request.SetPromiseAvailableTimeRequestDTO;
 import konkuk.kuit.baro.domain.promise.dto.response.*;
 import konkuk.kuit.baro.domain.promise.dto.response.PendingPromiseResponseDTO;
@@ -146,6 +147,17 @@ public class PromiseController {
     @CustomExceptionDescription(VOTE_INIT)
     public BaseResponse<Void> initVote(@PathVariable("promiseId") Long promiseId) {
         promiseService.initVote(promiseId);
+        return BaseResponse.ok(null);
+    }
+
+    @Tag(name = "약속 현황 API", description = "약속 현황 관련 API")
+    @Operation(summary = "투표하기", description = "실제로 원하는 시간, 장소에 투표합니다.")
+    @PostMapping("/{promiseId}/vote")
+    @CustomExceptionDescription(VOTE)
+    public BaseResponse<Void> vote(@CurrentUserId Long userId,
+                                   @PathVariable("promiseId") Long promiseId,
+                                   @RequestBody @Valid PromiseVoteRequestDTO promiseVoteRequestDTO) {
+        promiseService.vote(userId, promiseId, promiseVoteRequestDTO);
         return BaseResponse.ok(null);
     }
 

--- a/src/main/java/konkuk/kuit/baro/domain/promise/controller/PromiseController.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/controller/PromiseController.java
@@ -1,5 +1,6 @@
 package konkuk.kuit.baro.domain.promise.controller;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -158,6 +159,15 @@ public class PromiseController {
                                    @PathVariable("promiseId") Long promiseId,
                                    @RequestBody @Valid PromiseVoteRequestDTO promiseVoteRequestDTO) {
         promiseService.vote(userId, promiseId, promiseVoteRequestDTO);
+        return BaseResponse.ok(null);
+    }
+
+    @Tag(name = "약속 현황 API", description = "약속 현황 관련 API")
+    @Operation(summary = "투표 종료하기", description = "투표를 종료하며, 투표 내역을 확인하여 약속 시간, 장소를 확정합니다.")
+    @PostMapping("/{promiseId}/close-vote")
+    @CustomExceptionDescription(CLOSE_VOTE)
+    public BaseResponse<Void> closeVote(@PathVariable("promiseId") Long promiseId) {
+        promiseService.closeVote(promiseId);
         return BaseResponse.ok(null);
     }
 

--- a/src/main/java/konkuk/kuit/baro/domain/promise/controller/PromiseController.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/controller/PromiseController.java
@@ -14,7 +14,6 @@ import konkuk.kuit.baro.domain.promise.service.PromiseService;
 import konkuk.kuit.baro.global.auth.resolver.CurrentUserId;
 import konkuk.kuit.baro.global.common.annotation.CustomExceptionDescription;
 import konkuk.kuit.baro.global.common.response.BaseResponse;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.annotation.Validated;
@@ -139,4 +138,16 @@ public class PromiseController {
                                                                            @RequestParam("hasVoted") boolean hasVoted) {
         return BaseResponse.ok(promiseService.getVoteCandidateList(userId, promiseId, hasVoted));
     }
+
+
+    @Tag(name = "약속 현황 API", description = "약속 현황 관련 API")
+    @Operation(summary = "투표 시작(개설)하기", description = "약속 가능 시간, 약속 제안 장소 데이터를 바탕으로 투표 목록을 생성, 및 투표를 시작(개설)합니다.")
+    @PostMapping("/{promiseId}/init-vote")
+    @CustomExceptionDescription(VOTE_INIT)
+    public BaseResponse<Void> initVote(@PathVariable("promiseId") Long promiseId) {
+        promiseService.initVote(promiseId);
+        return BaseResponse.ok(null);
+    }
+
+
 }

--- a/src/main/java/konkuk/kuit/baro/domain/promise/dto/request/PromiseVoteRequestDTO.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/dto/request/PromiseVoteRequestDTO.java
@@ -1,0 +1,2 @@
+package konkuk.kuit.baro.domain.promise.dto.request;public class PromiseVoteRequestDTO {
+}

--- a/src/main/java/konkuk/kuit/baro/domain/promise/dto/request/PromiseVoteRequestDTO.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/dto/request/PromiseVoteRequestDTO.java
@@ -1,2 +1,23 @@
-package konkuk.kuit.baro.domain.promise.dto.request;public class PromiseVoteRequestDTO {
+package konkuk.kuit.baro.domain.promise.dto.request;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class PromiseVoteRequestDTO {
+
+    @NotEmpty(message = "최소 하나 이상의 약속 후보 시간에 투표해야합니다.")
+    @Schema(description = "투표한 약속 후보 시간들의 식별 ID", example = "[1, 2, 3]")
+    private List<Long> promiseCandidateTimeIds;
+
+    @NotEmpty(message = "최소 하나 이상의 약속 후보 장소에 투표해야합니다.")
+    @Schema(description = "투표한 약속 후보 장소들의 식별 ID", example = "[1, 2, 3]")
+    private List<Long> promiseCandidatePlaceIds;
 }

--- a/src/main/java/konkuk/kuit/baro/domain/promise/repository/PromiseAvailableTimeRepository.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/repository/PromiseAvailableTimeRepository.java
@@ -32,4 +32,11 @@ public interface PromiseAvailableTimeRepository extends JpaRepository<PromiseAva
             "THEN TRUE ELSE FALSE END")
     boolean existsPromiseAvailableTimeByPromiseMemberId(@Param("promiseMemberId") Long promiseMemberId);
 
+    // 특정 약속에 대한 모든 약속 가능 시간 조회
+    @Query("SELECT pat FROM PromiseAvailableTime pat " +
+            "JOIN pat.promiseMember pm " +
+            "JOIN pm.promise p " +
+            "WHERE p.id = :promiseId")
+    List<PromiseAvailableTime> findAllByPromiseId(@Param("promiseId") Long promiseId);
+
 }

--- a/src/main/java/konkuk/kuit/baro/domain/promise/repository/PromiseSuggestedPlaceRepository.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/repository/PromiseSuggestedPlaceRepository.java
@@ -1,10 +1,14 @@
 package konkuk.kuit.baro.domain.promise.repository;
 
+import konkuk.kuit.baro.domain.place.model.Place;
 import konkuk.kuit.baro.domain.promise.model.PromiseSuggestedPlace;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface PromiseSuggestedPlaceRepository extends JpaRepository<PromiseSuggestedPlace, Long> {
@@ -23,4 +27,14 @@ public interface PromiseSuggestedPlaceRepository extends JpaRepository<PromiseSu
             "THEN TRUE ELSE FALSE END")
     boolean existsPromiseSuggestedPlaceByPromiseMemberId(@Param("promiseMemberId") Long promiseMemberId);
 
+
+    // 특정 약속에 대한 약속 제안 장소들 중, 가장 제안이 많이 된 장소 순으로 내림차순 정렬
+    @Query("""
+            SELECT p.place
+            FROM PromiseSuggestedPlace p
+            WHERE p.promiseMember.promise.id = :promiseId
+            GROUP BY p.place
+            ORDER BY COUNT(p.place) DESC
+            """)
+    List<Place> findTopPlacesByPromiseId(@Param("promiseId") Long promiseId, Pageable pageable);
 }

--- a/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
@@ -1,7 +1,7 @@
 package konkuk.kuit.baro.domain.promise.service;
 
+import jakarta.persistence.EntityManager;
 import konkuk.kuit.baro.domain.place.model.Place;
-import konkuk.kuit.baro.domain.place.repository.PlaceRepository;
 import konkuk.kuit.baro.domain.promise.dto.request.PromiseSuggestRequestDTO;
 import konkuk.kuit.baro.domain.promise.dto.response.PendingPromiseResponseDTO;
 import konkuk.kuit.baro.domain.promise.dto.response.PromiseMemberSuggestStateDTO;
@@ -11,36 +11,42 @@ import konkuk.kuit.baro.domain.promise.dto.response.PromiseManagementResponseDTO
 import konkuk.kuit.baro.domain.promise.dto.response.SuggestedPromiseResponseDTO;
 import konkuk.kuit.baro.domain.promise.dto.response.VotingPromiseResponseDTO;
 import konkuk.kuit.baro.domain.promise.dto.response.*;
-import konkuk.kuit.baro.domain.promise.model.Promise;
-import konkuk.kuit.baro.domain.promise.model.PromiseMember;
+import konkuk.kuit.baro.domain.promise.model.*;
 import konkuk.kuit.baro.domain.promise.repository.*;
 import konkuk.kuit.baro.domain.user.model.User;
 import konkuk.kuit.baro.domain.user.repository.UserRepository;
-import konkuk.kuit.baro.domain.vote.model.PromiseTimeVoteHistory;
 import konkuk.kuit.baro.domain.vote.model.PromiseVote;
 import konkuk.kuit.baro.domain.vote.repository.PromiseTimeVoteHistoryRepository;
+import konkuk.kuit.baro.domain.vote.repository.PromiseVoteRepository;
 import konkuk.kuit.baro.global.common.exception.CustomException;
+import konkuk.kuit.baro.global.common.response.status.BaseStatus;
 import konkuk.kuit.baro.global.common.response.status.ErrorCode;
 import konkuk.kuit.baro.global.common.util.ColorUtil;
 import konkuk.kuit.baro.global.common.util.DateUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.parameters.P;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.*;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import static konkuk.kuit.baro.domain.promise.dto.response.SuggestionProgress.*;
+import static konkuk.kuit.baro.global.common.response.status.BaseStatus.*;
+import static konkuk.kuit.baro.global.common.response.status.ErrorCode.*;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class PromiseService {
+    private final PromiseVoteRepository promiseVoteRepository;
 
     private final PromiseRepository promiseRepository;
     private final PromiseMemberRepository promiseMemberRepository;
@@ -48,7 +54,10 @@ public class PromiseService {
     private final PromiseAvailableTimeRepository promiseAvailableTimeRepository;
     private final PromiseSuggestedPlaceRepository promiseSuggestedPlaceRepository;
     private final PromiseTimeVoteHistoryRepository promiseTimeVoteHistoryRepository;
-    private final PlaceRepository placeRepository;
+    private final PromiseCandidateTimeRepository promiseCandidateTimeRepository;
+    private final PromiseCandidatePlaceRepository promiseCandidatePlaceRepository;
+
+    private final EntityManager em;
 
     private final ColorUtil colorUtil;
 
@@ -185,7 +194,7 @@ public class PromiseService {
         LocalTime fixedTime = findPromise.getFixedTime();
 
         if (fixedPlace == null || fixedDate == null || fixedTime == null) {
-            throw new CustomException(ErrorCode.PROMISE_NOT_CONFIRMED);
+            throw new CustomException(PROMISE_NOT_CONFIRMED);
         }
 
         return new PromiseStatusConfirmedPromiseResponseDTO(
@@ -250,30 +259,54 @@ public class PromiseService {
         return new VoteCandidateListResponseDTO(candidateTimes, candidatePlaces);
     }
 
+
+    // 투표 시작(개설)하기
+    @Transactional
+    public void initVote(Long promiseId) {
+        // 투표 생성
+        PromiseVote promiseVote = PromiseVote.builder()
+                .voteEndTime(LocalDateTime.now().plusDays(3))
+                .build();
+
+        PromiseVote savedVote = promiseVoteRepository.save(promiseVote);
+
+        // 약속 정보 업데이트
+        Promise findPromise = findPromise(promiseId);
+        findPromise.setPromiseVote(savedVote);
+        findPromise.setStatus(VOTING);
+
+        // 약속 후보 시간 추출 - 약속 제안 시간에서 빈도수 기준 상위 3개 가져오기
+        saveTop3CandidateTimes(promiseId, savedVote);
+
+        // 약속 후보 장소 추출 - 약속 제안 장소에서 빈도수 기준 상위 3개 가져오기
+        saveTop3CandidatePlaces(promiseId, savedVote);
+    }
+
+
     private User findLoginUser(Long userId) {
         return userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
     }
 
     private Promise findPromise(Long promiseId) {
         return promiseRepository.findById(promiseId)
-                .orElseThrow(() -> new CustomException(ErrorCode.PROMISE_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(PROMISE_NOT_FOUND));
     }
 
     private PromiseMember findPromiseMember(Long userId, Long promiseId) {
 
         if (!userIsExist(userId)) {
-            throw new CustomException(ErrorCode.USER_NOT_FOUND);
+            throw new CustomException(USER_NOT_FOUND);
         }
 
         if (!promiseIsExist(promiseId)) {
-            throw new CustomException(ErrorCode.PROMISE_NOT_FOUND);
+            throw new CustomException(PROMISE_NOT_FOUND);
         }
 
         PromiseMember findPromiseMember = promiseMemberRepository.findByUserIdAndPromiseId(userId, promiseId);
 
         if (findPromiseMember == null) {
-            throw new CustomException(ErrorCode.PROMISE_MEMBER_NOT_FOUND);
+            throw new CustomException(PROMISE_MEMBER_NOT_FOUND);
         }
 
         return findPromiseMember;
@@ -281,7 +314,7 @@ public class PromiseService {
 
     private List<PromiseMember> findAllPromiseMembers(Long promiseId) {
         if (!promiseIsExist(promiseId)) {
-            throw new CustomException(ErrorCode.PROMISE_NOT_FOUND);
+            throw new CustomException(PROMISE_NOT_FOUND);
         }
 
         return promiseMemberRepository.findAllByPromiseId(promiseId);
@@ -291,7 +324,7 @@ public class PromiseService {
         PromiseVote findPromiseVote = promise.getPromiseVote();
 
         if (findPromiseVote == null) {
-            throw new CustomException(ErrorCode.PROMISE_VOTE_NOT_STARTED);
+            throw new CustomException(PROMISE_VOTE_NOT_STARTED);
         }
 
         return findPromiseVote;
@@ -417,6 +450,60 @@ public class PromiseService {
                         hasVoted && selectedTimeIds.contains(promiseCandidateTime.getId()) // 투표했으면 true
                 ))
                 .toList();
+    }
+
+    // 두 약속 가능 시간이 겹치는지 확인
+    private boolean isOverlapping(PromiseAvailableTime base, PromiseAvailableTime other) {
+        return base.getAvailableDate().isEqual(other.getAvailableDate()) &&
+                !base.getAvailableEndTime().isBefore(other.getAvailableStartTime()) &&
+                !base.getAvailableStartTime().isAfter(other.getAvailableEndTime());
+    }
+
+    // 상위 3개의 약속 가능 시간를 찾아서 약속 후보 시간으로 설정
+    private void saveTop3CandidateTimes(Long promiseId, PromiseVote savedVote) {
+        List<PromiseAvailableTime> allAvailableTimes = promiseAvailableTimeRepository.findAllByPromiseId(promiseId);
+
+        if(allAvailableTimes.isEmpty()) {
+            throw new CustomException(PROMISE_AVAILABLE_TIME_NOT_FOUND);
+        }
+
+        Map<PromiseAvailableTime, Integer> overlapCountMap = new ConcurrentHashMap<>();
+
+        for (PromiseAvailableTime base : allAvailableTimes) {
+            int count = 0;
+            for (PromiseAvailableTime other : allAvailableTimes) {
+                if (base == other) continue;
+                if (isOverlapping(base, other)) {
+                    count++;
+                }
+            }
+            overlapCountMap.put(base, count);
+        }
+
+        overlapCountMap.entrySet().stream()
+                .sorted((e1, e2) -> e2.getValue() - e1.getValue())
+                .limit(3)
+                .map(Map.Entry::getKey)
+                .map(pat -> PromiseCandidateTime.createPromiseCandidateTime(
+                        pat.getAvailableDate(),
+                        pat.getAvailableStartTime(),
+                        savedVote
+                ))
+                .forEach(promiseCandidateTimeRepository::save);
+    }
+
+    // 상위 3개의 약속 제안 장소를 찾아서 약속 후보 장소로 설정
+    private void saveTop3CandidatePlaces(Long promiseId, PromiseVote savedVote) {
+        List<Place> top3PromiseSuggestedPlaces = promiseSuggestedPlaceRepository.findTopPlacesByPromiseId(promiseId, PageRequest.of(0, 3));
+
+        if(top3PromiseSuggestedPlaces.isEmpty()) {
+            throw new CustomException(PROMISE_SUGGESTED_PLACE_NOT_FOUND);
+        }
+
+        top3PromiseSuggestedPlaces.forEach(place -> {
+            PromiseCandidatePlace candidatePlace = PromiseCandidatePlace.createPromiseCandidatePlace(savedVote, place);
+            promiseCandidatePlaceRepository.save(candidatePlace);
+        });
     }
 
 

--- a/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
@@ -501,8 +501,8 @@ public class PromiseService {
     // 두 약속 가능 시간이 겹치는지 확인
     private boolean isOverlapping(PromiseAvailableTime base, PromiseAvailableTime other) {
         return base.getAvailableDate().isEqual(other.getAvailableDate()) &&
-                !base.getAvailableEndTime().isBefore(other.getAvailableStartTime()) &&
-                !base.getAvailableStartTime().isAfter(other.getAvailableEndTime());
+                base.getAvailableEndTime().isAfter(other.getAvailableStartTime()) &&
+                base.getAvailableStartTime().isBefore(other.getAvailableEndTime());
     }
 
     // 상위 3개의 약속 가능 시간를 찾아서 약속 후보 시간으로 설정

--- a/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
+++ b/src/main/java/konkuk/kuit/baro/domain/promise/service/PromiseService.java
@@ -285,6 +285,7 @@ public class PromiseService {
     }
 
 
+    // 투표하기
     @Transactional
     public void vote(Long userId, Long promiseId, PromiseVoteRequestDTO promiseVoteRequestDTO) {
         Promise findPromise = findPromise(promiseId);
@@ -300,26 +301,11 @@ public class PromiseService {
         promiseTimeVoteHistoryRepository.deleteAllByPromiseMember(findPromiseMember);
         promisePlaceVoteHistoryRepository.deleteAllByPromiseMember(findPromiseMember);
 
-
         // 시간 투표 내역 저장
-        promiseVoteRequestDTO.getPromiseCandidateTimeIds()
-                .stream()
-                .map(promiseCandidateTimeId -> promiseCandidateTimeRepository.findById(promiseCandidateTimeId).orElseThrow(
-                        () -> new CustomException(PROMISE_CANDIDATE_TIME_NOT_FOUND)
-                ))
-                .map(promiseCandidateTime -> PromiseTimeVoteHistory.createPromiseTimeVoteHistory(findPromiseVote, promiseCandidateTime, findPromiseMember))
-                .forEach(promiseTimeVoteHistoryRepository::save);
-
+        saveTimeVoteHistory(promiseVoteRequestDTO.getPromiseCandidateTimeIds(), findPromiseVote, findPromiseMember);
 
         // 장소 투표 내역 저장
-        promiseVoteRequestDTO.getPromiseCandidatePlaceIds()
-                .stream()
-                .map(promiseCandidatePlaceId -> promiseCandidatePlaceRepository.findById(promiseCandidatePlaceId).orElseThrow(
-                        () -> new CustomException(PROMISE_CANDIDATE_PLACE_NOT_FOUND)
-                ))
-                .map(promiseCandidatePlace -> PromisePlaceVoteHistory.createPromisePlaceVoteHistory(promiseCandidatePlace, findPromiseVote, findPromiseMember))
-                .forEach(promisePlaceVoteHistoryRepository::save);
-
+        savePlaceVoteHistory(promiseVoteRequestDTO.getPromiseCandidatePlaceIds(), findPromiseVote, findPromiseMember);
     }
 
 
@@ -544,6 +530,29 @@ public class PromiseService {
             PromiseCandidatePlace candidatePlace = PromiseCandidatePlace.createPromiseCandidatePlace(savedVote, place);
             promiseCandidatePlaceRepository.save(candidatePlace);
         });
+    }
+
+    // 시간 투표 내역 저장
+    private void saveTimeVoteHistory(List<Long> promiseCandidateTimeIds, PromiseVote findPromiseVote, PromiseMember findPromiseMember) {
+        promiseCandidateTimeIds
+                .stream()
+                .map(promiseCandidateTimeId -> promiseCandidateTimeRepository.findById(promiseCandidateTimeId).orElseThrow(
+                        () -> new CustomException(PROMISE_CANDIDATE_TIME_NOT_FOUND)
+                ))
+                .map(promiseCandidateTime -> PromiseTimeVoteHistory.createPromiseTimeVoteHistory(findPromiseVote, promiseCandidateTime, findPromiseMember))
+
+                .forEach(promiseTimeVoteHistoryRepository::save);
+    }
+
+    // 장소 투표 내역 저장
+    private void savePlaceVoteHistory(List<Long> promiseCandidatePlaceIds, PromiseVote findPromiseVote, PromiseMember findPromiseMember) {
+        promiseCandidatePlaceIds
+                .stream()
+                .map(promiseCandidatePlaceId -> promiseCandidatePlaceRepository.findById(promiseCandidatePlaceId).orElseThrow(
+                        () -> new CustomException(PROMISE_CANDIDATE_PLACE_NOT_FOUND)
+                ))
+                .map(promiseCandidatePlace -> PromisePlaceVoteHistory.createPromisePlaceVoteHistory(promiseCandidatePlace, findPromiseVote, findPromiseMember))
+                .forEach(promisePlaceVoteHistoryRepository::save);
     }
 
 

--- a/src/main/java/konkuk/kuit/baro/domain/vote/repository/PromisePlaceVoteHistoryRepository.java
+++ b/src/main/java/konkuk/kuit/baro/domain/vote/repository/PromisePlaceVoteHistoryRepository.java
@@ -1,9 +1,12 @@
 package konkuk.kuit.baro.domain.vote.repository;
 
+import konkuk.kuit.baro.domain.promise.model.PromiseMember;
 import konkuk.kuit.baro.domain.vote.model.PromisePlaceVoteHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PromisePlaceVoteHistoryRepository extends JpaRepository<PromisePlaceVoteHistory, Long> {
+
+    void deleteAllByPromiseMember(PromiseMember promiseMember);
 }

--- a/src/main/java/konkuk/kuit/baro/domain/vote/repository/PromisePlaceVoteHistoryRepository.java
+++ b/src/main/java/konkuk/kuit/baro/domain/vote/repository/PromisePlaceVoteHistoryRepository.java
@@ -1,12 +1,28 @@
 package konkuk.kuit.baro.domain.vote.repository;
 
+import konkuk.kuit.baro.domain.promise.model.PromiseCandidatePlace;
 import konkuk.kuit.baro.domain.promise.model.PromiseMember;
 import konkuk.kuit.baro.domain.vote.model.PromisePlaceVoteHistory;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface PromisePlaceVoteHistoryRepository extends JpaRepository<PromisePlaceVoteHistory, Long> {
 
     void deleteAllByPromiseMember(PromiseMember promiseMember);
+
+    // 약속 장소 투표 내역을 확인하여, 가장 많이 투표된 약속 후보 시간별로 내림차순 정렬하여 반환
+    @Query("""
+            SELECT ppvh.promiseCandidatePlace
+            FROM PromisePlaceVoteHistory ppvh
+            WHERE ppvh.promiseVote.id = :promiseVoteId
+            GROUP BY ppvh.promiseCandidatePlace
+            ORDER BY COUNT(ppvh) DESC
+            """)
+    List<PromiseCandidatePlace> findMostVotedCandidatePlace(@Param("promiseVoteId") Long promiseVoteId, Pageable pageable);
 }

--- a/src/main/java/konkuk/kuit/baro/domain/vote/repository/PromiseTimeVoteHistoryRepository.java
+++ b/src/main/java/konkuk/kuit/baro/domain/vote/repository/PromiseTimeVoteHistoryRepository.java
@@ -1,10 +1,16 @@
 package konkuk.kuit.baro.domain.vote.repository;
 
+import konkuk.kuit.baro.domain.promise.model.PromiseCandidateTime;
 import konkuk.kuit.baro.domain.promise.model.PromiseMember;
 import konkuk.kuit.baro.domain.vote.model.PromiseTimeVoteHistory;
 import konkuk.kuit.baro.domain.vote.model.PromiseVote;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface PromiseTimeVoteHistoryRepository extends JpaRepository<PromiseTimeVoteHistory, Long> {
@@ -14,4 +20,14 @@ public interface PromiseTimeVoteHistoryRepository extends JpaRepository<PromiseT
     boolean existsByPromiseVoteAndPromiseMember(PromiseVote promiseVote, PromiseMember promiseMember);
 
     void deleteAllByPromiseMember(PromiseMember promiseMember);
+
+    // 약속 시간 투표 내역을 확인하여, 가장 많이 투표된 약속 후보 시간별로 내림차순 정렬하여 반환
+    @Query("""
+            SELECT ptvh.promiseCandidateTime
+            FROM PromiseTimeVoteHistory ptvh
+            WHERE ptvh.promiseVote.id = :promiseVoteId
+            GROUP BY ptvh.promiseCandidateTime
+            ORDER BY COUNT(ptvh) DESC
+            """)
+    List<PromiseCandidateTime> findMostVotedCandidateTime(@Param("promiseVoteId") Long promiseVoteId, Pageable pageable);
 }

--- a/src/main/java/konkuk/kuit/baro/domain/vote/repository/PromiseTimeVoteHistoryRepository.java
+++ b/src/main/java/konkuk/kuit/baro/domain/vote/repository/PromiseTimeVoteHistoryRepository.java
@@ -12,4 +12,6 @@ public interface PromiseTimeVoteHistoryRepository extends JpaRepository<PromiseT
     boolean existsByPromiseVoteId(Long promiseVoteId);
 
     boolean existsByPromiseVoteAndPromiseMember(PromiseVote promiseVote, PromiseMember promiseMember);
+
+    void deleteAllByPromiseMember(PromiseMember promiseMember);
 }

--- a/src/main/java/konkuk/kuit/baro/global/common/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/kuit/baro/global/common/config/swagger/SwaggerResponseDescription.java
@@ -102,7 +102,7 @@ public enum SwaggerResponseDescription {
 
     VOTING_PROMISE_STATUS(new LinkedHashSet<>(Set.of(
             PROMISE_NOT_FOUND,
-            PROMISE_VOTE_NOT_STARTED
+            PROMISE_VOTE_NOT_IN_PROGRESS
     ))),
 
     CONFIRMED_PROMISE_STATUS(new LinkedHashSet<>(Set.of(
@@ -117,7 +117,7 @@ public enum SwaggerResponseDescription {
 
     PROMISE_VOTE_REMAINING_TIME(new LinkedHashSet<>(Set.of(
             PROMISE_NOT_FOUND,
-            PROMISE_VOTE_NOT_STARTED,
+            PROMISE_VOTE_NOT_IN_PROGRESS,
             TIME_EXCEED
     ))),
 
@@ -125,20 +125,29 @@ public enum SwaggerResponseDescription {
             USER_NOT_FOUND,
             PROMISE_NOT_FOUND,
             PROMISE_MEMBER_NOT_FOUND,
-            PROMISE_VOTE_NOT_STARTED
+            PROMISE_VOTE_NOT_IN_PROGRESS
     ))),
 
     VOTE_CANDIDATE_LIST(new LinkedHashSet<>(Set.of(
             USER_NOT_FOUND,
             PROMISE_NOT_FOUND,
             PROMISE_MEMBER_NOT_FOUND,
-            PROMISE_VOTE_NOT_STARTED
+            PROMISE_VOTE_NOT_IN_PROGRESS
     ))),
 
     VOTE_INIT(new LinkedHashSet<>(Set.of(
             PROMISE_NOT_FOUND,
             PROMISE_AVAILABLE_TIME_NOT_FOUND,
             PROMISE_SUGGESTED_PLACE_NOT_FOUND
+    ))),
+
+    VOTE(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND,
+            PROMISE_NOT_FOUND,
+            PROMISE_MEMBER_NOT_FOUND,
+            PROMISE_VOTE_NOT_IN_PROGRESS,
+            PROMISE_CANDIDATE_TIME_NOT_FOUND,
+            PROMISE_CANDIDATE_PLACE_NOT_FOUND
     )));
 
     private final Set<ErrorCode> errorCodeList;

--- a/src/main/java/konkuk/kuit/baro/global/common/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/kuit/baro/global/common/config/swagger/SwaggerResponseDescription.java
@@ -133,6 +133,12 @@ public enum SwaggerResponseDescription {
             PROMISE_NOT_FOUND,
             PROMISE_MEMBER_NOT_FOUND,
             PROMISE_VOTE_NOT_STARTED
+    ))),
+
+    VOTE_INIT(new LinkedHashSet<>(Set.of(
+            PROMISE_NOT_FOUND,
+            PROMISE_AVAILABLE_TIME_NOT_FOUND,
+            PROMISE_SUGGESTED_PLACE_NOT_FOUND
     )));
 
     private final Set<ErrorCode> errorCodeList;

--- a/src/main/java/konkuk/kuit/baro/global/common/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/kuit/baro/global/common/config/swagger/SwaggerResponseDescription.java
@@ -148,6 +148,13 @@ public enum SwaggerResponseDescription {
             PROMISE_VOTE_NOT_IN_PROGRESS,
             PROMISE_CANDIDATE_TIME_NOT_FOUND,
             PROMISE_CANDIDATE_PLACE_NOT_FOUND
+    ))),
+
+    CLOSE_VOTE(new LinkedHashSet<>(Set.of(
+            PROMISE_NOT_FOUND,
+            PROMISE_VOTE_NOT_IN_PROGRESS,
+            PROMISE_TIME_NOT_CONFIRMED,
+            PROMISE_PLACE_NOT_CONFIRMED
     )));
 
     private final Set<ErrorCode> errorCodeList;

--- a/src/main/java/konkuk/kuit/baro/global/common/response/status/ErrorCode.java
+++ b/src/main/java/konkuk/kuit/baro/global/common/response/status/ErrorCode.java
@@ -56,9 +56,12 @@ public enum ErrorCode implements ResponseStatus {
 
     // PromiseVote
     PROMISE_VOTE_NOT_STARTED(800, BAD_REQUEST.value(), "아직 투표가 개설되지 않았습니다."),
+    PROMISE_AVAILABLE_TIME_NOT_FOUND(801, HttpStatus.NOT_FOUND.value(), "약속 가능 시간이 존재하지 않습니다."),
+    PROMISE_SUGGESTED_PLACE_NOT_FOUND(802, HttpStatus.NOT_FOUND.value(), "약속 제안 장소가 존재하지 않습니다."),
 
     // Time
     TIME_EXCEED(900, BAD_REQUEST.value(), "만료시간이 지났습니다");
+
 
 
     @Getter

--- a/src/main/java/konkuk/kuit/baro/global/common/response/status/ErrorCode.java
+++ b/src/main/java/konkuk/kuit/baro/global/common/response/status/ErrorCode.java
@@ -55,9 +55,11 @@ public enum ErrorCode implements ResponseStatus {
     PROMISE_MEMBER_NOT_FOUND(700, HttpStatus.NOT_FOUND.value(), "해당 약속에 참여한 사용자가 아닙니다."),
 
     // PromiseVote
-    PROMISE_VOTE_NOT_STARTED(800, BAD_REQUEST.value(), "아직 투표가 개설되지 않았습니다."),
+    PROMISE_VOTE_NOT_IN_PROGRESS(800, BAD_REQUEST.value(), "투표중이 아닙니다."),
     PROMISE_AVAILABLE_TIME_NOT_FOUND(801, HttpStatus.NOT_FOUND.value(), "약속 가능 시간이 존재하지 않습니다."),
     PROMISE_SUGGESTED_PLACE_NOT_FOUND(802, HttpStatus.NOT_FOUND.value(), "약속 제안 장소가 존재하지 않습니다."),
+    PROMISE_CANDIDATE_TIME_NOT_FOUND(803, HttpStatus.NOT_FOUND.value(), "해당 약속 후보 시간이 존재하지 않습니다."),
+    PROMISE_CANDIDATE_PLACE_NOT_FOUND(804, HttpStatus.NOT_FOUND.value(), "해당 약속 후보 장소가 존재하지 않습니다."),
 
     // Time
     TIME_EXCEED(900, BAD_REQUEST.value(), "만료시간이 지났습니다");

--- a/src/main/java/konkuk/kuit/baro/global/common/response/status/ErrorCode.java
+++ b/src/main/java/konkuk/kuit/baro/global/common/response/status/ErrorCode.java
@@ -60,6 +60,8 @@ public enum ErrorCode implements ResponseStatus {
     PROMISE_SUGGESTED_PLACE_NOT_FOUND(802, HttpStatus.NOT_FOUND.value(), "약속 제안 장소가 존재하지 않습니다."),
     PROMISE_CANDIDATE_TIME_NOT_FOUND(803, HttpStatus.NOT_FOUND.value(), "해당 약속 후보 시간이 존재하지 않습니다."),
     PROMISE_CANDIDATE_PLACE_NOT_FOUND(804, HttpStatus.NOT_FOUND.value(), "해당 약속 후보 장소가 존재하지 않습니다."),
+    PROMISE_TIME_NOT_CONFIRMED(805, BAD_REQUEST.value(), "약속 시간이 확정되지 않았습니다."),
+    PROMISE_PLACE_NOT_CONFIRMED(806, BAD_REQUEST.value(), "약속 장소가 확정되지 않았습니다."),
 
     // Time
     TIME_EXCEED(900, BAD_REQUEST.value(), "만료시간이 지났습니다");


### PR DESCRIPTION
## Related issue 🛠
- closed #52 

## Work Description 📝

### 투표 시작하기
투표 시작(개설)하기 API 는 새롭게 투표 엔티티를 생성하고 DB에 save합니다.

이 때 promise 엔티티에 대해서도 새롭게 생성된 투표에 대한 정보가 연관관계로 걸려야하므로 JPA의 변경감지를 통해 연관관계를 걸어주었고, 약속의 상태또한 PENDING -> VOTING 으로 바뀌도록 해주었습니다. 이 역시 마찬가지로 변경 감지를 활용하였습니다.

또한 약속에 참여한 약속 참여자들이 표시한 약속 가능 시간, 약속 제안 장소를 확인하여서 투표의 후보로 올라갈 목록들을 추려냅니다. 이 때는 특정 시간대, 장소가 가능하다고 표시된 빈도를 기준으로 정렬하여 상위 3개의 항목들만 투표 항목으로 선별합니다.

### 투표하기
투표 시작(개설)하기 API 에서 생성한 투표 후보 시간, 투표 후보 장소 를 클라이언트에게 보여주고, 클라이언트 측에서 해당 목록들을 선택하여 요청을 다시 보내게되면, 서버는 그 요청값을 받아서 약속 시간 투표 내역, 약속 장소 투표 내역 엔티티를 만들어 DB에 저장합니다.

이 두 엔티티는 추후에 약속 확정 시간, 약속 확정 장소를 정하는 데에 사용됩니다.

### 투표 종료하기
투표 종료하기에서는 투표가 진행되는 동안 DB에 쌓인 약속 시간 투표 내역, 약속 장소 투표 내역을 확인하고, 각각의 투표 후보 항목들 중 가장 많이 투표된 약속 후보 시간, 약속 후보 장소를 얻어냅니다.
그렇게 얻어낸 약속 후보 시간, 약속 후보 장소에서 각각 약속 날짜, 시간, 장소를 얻어내고 해당 값들을 가지고 promise 엔티티에 fixedDate, fixedTime, place 에 값을 설정해줍니다.

이 값들은 추후에 약속 현황 - 확정 API 에 반환됩니다.


## Screenshot 📸

## Uncompleted Tasks 😅
- 없습니다.

## To Reviewers 📢
일단 후딱 끝내버리려고 하나의 PR에 이거저거 다 넣어버려서 코드 변경 사항이 좀 많을 수 있습니다.. 죄송합니다